### PR TITLE
Add access to the viewer inside the window manager for handling events.

### DIFF
--- a/include/gepetto/viewer/window-manager.h
+++ b/include/gepetto/viewer/window-manager.h
@@ -117,6 +117,9 @@ namespace graphics {
         /** Return the window width and height as a 2D vector */
         osgVector2 getWindowDimension () const;
 
+        /** Return a ref to the viewer */
+        ::osgViewer::ViewerRefPtr getViewerClone();
+
         virtual ~WindowManager();
     };
 } /* namespace graphics */

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -77,9 +77,9 @@ namespace graphics {
 	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
 	  }
           link->setStaticTransform(static_pos,static_quat);
-          link->setScale(osgVector3(mesh_shared_ptr->scale.x,
-                                    mesh_shared_ptr->scale.y,
-                                    mesh_shared_ptr->scale.z));
+          link->setScale(osgVector3((float)mesh_shared_ptr->scale.x,
+                                    (float)mesh_shared_ptr->scale.y,
+                                    (float)mesh_shared_ptr->scale.z));
           // add links to robot node
           robot->addChild(link);
         }
@@ -136,9 +136,9 @@ namespace graphics {
       if ( box_shared_ptr != 0 ) {
 	LeafNodeBoxPtr_t link = LeafNodeBox::create
 	  (robotName + "/" + link_name,
-	   osgVector3(.5*(float)box_shared_ptr->dim.x,
-		      .5*(float)box_shared_ptr->dim.y,
-		      .5*(float)box_shared_ptr->dim.z));
+	   osgVector3((float)(.5*box_shared_ptr->dim.x),
+		      (float)(.5*box_shared_ptr->dim.y), 
+		      (float)(.5*box_shared_ptr->dim.z)));
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
 	    getStaticTransform (urdfLink, static_pos, static_quat, visual);

--- a/src/window-manager.cpp
+++ b/src/window-manager.cpp
@@ -205,7 +205,12 @@ namespace graphics {
         viewer_ptr_ = NULL;
 
     }
-
+  
+  osgViewer::ViewerRefPtr WindowManager::getViewerClone()
+  {
+    return ::osgViewer::ViewerRefPtr(viewer_ptr_.get());
+  }
+  
     /* End declaration of public function members */
 
 } /* namespace graphics */


### PR DESCRIPTION
This is necessary to handle key event.
The second commit removing warnings.