### PR TITLE
standalone MT viewer version ( not IDL compliant)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,20 +24,31 @@ SET (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJ_MODULE_PATH})
 
 SET(CXX_DISABLE_WERROR TRUE)
 INCLUDE(cmake/base.cmake)
+INCLUDE(cmake/boost.cmake)
 INCLUDE(cmake/eigen.cmake)
-#INCLUDE(cmake/cpack.cmake)
+INCLUDE(cmake/cpack.cmake)
+INCLUDE(cmake/python.cmake)
 
-SET(PROJECT_NAME gepetto-viewer)
-SET(PROJECT_DESCRIPTION
-  "Implement simple Viewer using OpenSceneGraph."
-  )
+SET(PROJECT_NAME gepetto)
+SET(PROJECT_DESCRIPTION "Robot viewer")
 SET(PROJECT_URL "")
 
 # Where to compile shared objects
 SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-
 SETUP_PROJECT()
+
+IF(WIN32)
+  SET(LINK copy_if_different)
+ELSE(WIN32)
+  SET(LINK create_symlink)
+ENDIF(WIN32)
+SET(PROJECT_DESCRIPTION
+  "Implement simple Viewer using OpenSceneGraph."
+  )
+
+
+
 set(PINOCCHIO_PATH "${CMAKE_HOME_DIRECTORY}/../pinocchio" CACHE FILEPATH "${CMAKE_HOME_DIRECTORY}/../pinocchio")
 # Declare Headers
 SET(${PROJECT_NAME}_HEADERS
@@ -55,17 +66,112 @@ SET(${PROJECT_NAME}_HEADERS
  # include/gepetto/viewer/macros.h
  # include/gepetto/viewer/node.h
 include/gepetto/viewer/robot.h
+include/gepetto/viewer/viewer.h
+  include/gepetto/viewer/urdf-parser.h
+  include/gepetto/viewer/window-manager.h
+  include/gepetto/viewer/window-manager.h
+  include/gepetto/python/python.hpp
+include/gepetto/python/graphicrobot.hpp
+include/gepetto/python/graphicviewer.hpp
+)
+
+ SET(HEADERSPYTHON
+  #include/gepetto/viewer/config-osg.h
+  #include/gepetto/viewer/group-node.h
+  #include/gepetto/viewer/leaf-node-box.h
+ # include/gepetto/viewer/leaf-node-capsule.h
+  #include/gepetto/viewer/leaf-node-collada.h
+  #include/gepetto/viewer/leaf-node-cone.h
+ # include/gepetto/viewer/leaf-node-cylinder.h
+  #include/gepetto/viewer/leaf-node-face.h
+  #include/gepetto/viewer/leaf-node-ground.h
+ #include/gepetto/viewer/leaf-node-line.h
+ # include/gepetto/viewer/leaf-node-sphere.h
+ # include/gepetto/viewer/macros.h
+ # include/gepetto/viewer/node.h
+include/gepetto/viewer/robot.h
   include/gepetto/viewer/urdf-parser.h
   include/gepetto/viewer/window-manager.h
 )
+MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/${PROJECT_NAME}/python")
+
+FOREACH(header ${${PROJECT_NAME}_HEADERS})
+  GET_FILENAME_COMPONENT(headerName ${header} NAME)
+  GET_FILENAME_COMPONENT(headerPath ${header} PATH)
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E ${LINK}
+    ${${PROJECT_NAME}_SOURCE_DIR}/include/${header}
+    ${${PROJECT_NAME}_BINARY_DIR}/include/${PROJECT_NAME}/${header})
+  INSTALL(FILES ${${PROJECT_NAME}_SOURCE_DIR}/${header}
+	  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/${headerPath}
+          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ OWNER_WRITE)
+ENDFOREACH(header)
+
 find_package(OpenSceneGraph REQUIRED)
 find_package(Eigen3 REQUIRED)
 #ADD_REQUIRED_DEPENDENCY("openscenegraph >= 3.2")
 #ADD_REQUIRED_DEPENDENCY("openthreads >= 3.2")
+ADD_OPTIONAL_DEPENDENCY("eigenpy >= 1.2.0")
 ADD_REQUIRED_DEPENDENCY("urdfdom")
 
 ADD_SUBDIRECTORY(src)
+
 PKG_CONFIG_APPEND_LIBS(${PROJECT_NAME})
+
+IF(EIGENPY_FOUND)
+  FINDPYTHON()
+  MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/lib/python/${PROJECT_NAME}")
+
+  # --- COMPILE WRAPPER
+  SET(PYWRAP ${PROJECT_NAME}_pywrap)
+  ADD_LIBRARY(${PYWRAP} SHARED src/python/module.cpp src/python/python.cpp)
+  PKG_CONFIG_USE_DEPENDENCY(${PYWRAP} eigenpy)
+  IF(URDFDOM_FOUND)
+    PKG_CONFIG_USE_DEPENDENCY(${PYWRAP} urdfdom)
+
+  ENDIF(URDFDOM_FOUND)
+  TARGET_LINK_LIBRARIES(${PYWRAP} ${Boost_LIBRARIES} eigenpy ${OPENTHREADS_LIBRARIES}
+   ${OPENSCENEGRAPH_LIBRARIES} ${OSGVIEWER_LIBRARY} ${OSGDB_LIBRARY} ${OSGGA_LIBRARY} ${PROJECT_NAME})
+  SET_TARGET_PROPERTIES(${PYWRAP} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/python/${PROJECT_NAME}")
+  INSTALL(FILES
+    "${CMAKE_BINARY_DIR}/lib/python/${PROJECT_NAME}/lib${PYWRAP}.so"
+    DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME})
+
+  # --- INSTALL SCRIPTS
+  SET(PYTHON_FILES
+    python/__init__.py
+    #python/utils.py
+   # python/robot_wrapper.py
+   # python/rpy.py
+   # python/explog.py
+    )
+  FOREACH(python ${PYTHON_FILES})
+    GET_FILENAME_COMPONENT(pythonFile ${python} NAME)
+    EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E ${LINK}
+      ${${PROJECT_NAME}_SOURCE_DIR}/src/${python}
+      ${${PROJECT_NAME}_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile})
+
+    # Tag pyc file as generated.
+    SET_SOURCE_FILES_PROPERTIES(
+      "${CMAKE_CURRENT_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile}c"
+      PROPERTIES GENERATED TRUE)
+
+    EXECUTE_PROCESS(COMMAND
+      ${PYTHON_EXECUTABLE} -m py_compile
+      ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile} )
+
+    # Clean generated files.
+    SET_PROPERTY(
+      DIRECTORY APPEND PROPERTY
+      ADDITIONAL_MAKE_CLEAN_FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile}c")
+
+    INSTALL(FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile}"
+      "${CMAKE_CURRENT_BINARY_DIR}/lib/python/${PROJECT_NAME}/${pythonFile}c"
+      DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME})
+  ENDFOREACH(python)
+ENDIF(EIGENPY_FOUND)
 
 SETUP_PROJECT_FINALIZE()
 #SETUP_PROJECT_CPACK()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
+FILE(TO_CMAKE_PATH ${CMAKE_HOME_DIRECTORY}/cmake PROJ_MODULE_PATH)
+SET (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJ_MODULE_PATH})
+
 SET(CXX_DISABLE_WERROR TRUE)
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/eigen.cmake)
@@ -35,28 +38,30 @@ SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 
 SETUP_PROJECT()
-
+set(PINOCCHIO_PATH "${CMAKE_HOME_DIRECTORY}/../pinocchio" CACHE FILEPATH "${CMAKE_HOME_DIRECTORY}/../pinocchio")
 # Declare Headers
 SET(${PROJECT_NAME}_HEADERS
-  include/gepetto/viewer/config-osg.h
-  include/gepetto/viewer/group-node.h
-  include/gepetto/viewer/leaf-node-box.h
-  include/gepetto/viewer/leaf-node-capsule.h
-  include/gepetto/viewer/leaf-node-collada.h
-  include/gepetto/viewer/leaf-node-cone.h
-  include/gepetto/viewer/leaf-node-cylinder.h
-  include/gepetto/viewer/leaf-node-face.h
-  include/gepetto/viewer/leaf-node-ground.h
-  include/gepetto/viewer/leaf-node-line.h
-  include/gepetto/viewer/leaf-node-sphere.h
-  include/gepetto/viewer/macros.h
-  include/gepetto/viewer/node.h
+  #include/gepetto/viewer/config-osg.h
+  #include/gepetto/viewer/group-node.h
+  #include/gepetto/viewer/leaf-node-box.h
+ # include/gepetto/viewer/leaf-node-capsule.h
+  #include/gepetto/viewer/leaf-node-collada.h
+  #include/gepetto/viewer/leaf-node-cone.h
+ # include/gepetto/viewer/leaf-node-cylinder.h
+  #include/gepetto/viewer/leaf-node-face.h
+  #include/gepetto/viewer/leaf-node-ground.h
+ #include/gepetto/viewer/leaf-node-line.h
+ # include/gepetto/viewer/leaf-node-sphere.h
+ # include/gepetto/viewer/macros.h
+ # include/gepetto/viewer/node.h
+include/gepetto/viewer/robot.h
   include/gepetto/viewer/urdf-parser.h
   include/gepetto/viewer/window-manager.h
 )
-
-ADD_REQUIRED_DEPENDENCY("openscenegraph >= 3.2")
-ADD_REQUIRED_DEPENDENCY("openthreads >= 3.2")
+find_package(OpenSceneGraph REQUIRED)
+find_package(Eigen3 REQUIRED)
+#ADD_REQUIRED_DEPENDENCY("openscenegraph >= 3.2")
+#ADD_REQUIRED_DEPENDENCY("openthreads >= 3.2")
 ADD_REQUIRED_DEPENDENCY("urdfdom")
 
 ADD_SUBDIRECTORY(src)

--- a/include/gepetto/python/graphicrobot.hpp
+++ b/include/gepetto/python/graphicrobot.hpp
@@ -1,0 +1,183 @@
+#ifndef __se3_python_visualrobot_hpp__
+#define __se3_python_visualrobot_hpp__
+
+#include <pinocchio/multibody/model.hpp>
+#include <pinocchio/multibody/joint.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <eigenpy/exception.hpp>
+#include <eigenpy/eigenpy.hpp>
+
+#include <gepetto/viewer/robot.h>
+
+#include "gepetto/python/handler.hpp"
+
+namespace graphics
+{
+namespace python
+{
+namespace bp = boost::python;
+
+typedef Handler<  RobotUpdate  > RobotUpdateHandler;
+
+struct RobotUpdatePythonVisitor
+        : public boost::python::def_visitor< RobotUpdatePythonVisitor >
+{
+public:
+    // typedef Model::Index Index;
+    //typedef typename eigenpy::UnalignedEquivalent<Motion>::type Motion_fx;
+
+public:
+
+    /* --- Convert From C++ to Python ------------------------------------- */
+    // static PyObject* convert(Model const& modelConstRef)
+    // {
+    // 	Model * ptr = const_cast<Model*>(&modelConstRef);
+    // 	return boost::python::incref(boost::python::object(ModelHandler(ptr)).ptr());
+    // }
+    static PyObject* convert( RobotUpdateHandler::SmartPtr_t const& ptr)
+    {
+        return boost::python::incref(boost::python::object(RobotUpdateHandler(ptr)).ptr());
+    }
+
+    /* --- Exposing C++ API to python through the handler ----------------- */
+    template<class PyClass>
+    void visit(PyClass& cl) const
+    {
+        cl
+        .def("setConfiguration",&RobotUpdatePythonVisitor::setJointConfiguration)
+        .def("getVisuJointID",&RobotUpdatePythonVisitor::getJointID)
+        .def("setUrdfFile",&RobotUpdatePythonVisitor::setUrdfFile )
+        .def("setUrdfPackageDirectory",&RobotUpdatePythonVisitor::setUrdfPackageDirectory)
+        .def("setDebugCollisionOnOff",&RobotUpdatePythonVisitor::setDebugCollisionOnOff)
+        // .def("createData",&RobotUpdatePythonVisitor::createData)
+
+        .def("__str__",& RobotUpdatePythonVisitor::toString)
+        /*
+        	  .add_property("nq", &ModelPythonVisitor::nq)
+        	  .add_property("nv", &ModelPythonVisitor::nv)
+        	  .add_property("nbody", &ModelPythonVisitor::nbody)
+        	  .add_property("inertias",
+        			bp::make_function(&ModelPythonVisitor::inertias,
+        					  bp::return_internal_reference<>())  )
+        	  .add_property("jointPlacements",
+        			bp::make_function(&ModelPythonVisitor::jointPlacements,
+        					  bp::return_internal_reference<>())  )
+        	  .add_property("parents",
+        			bp::make_function(&ModelPythonVisitor::parents,
+        					  bp::return_internal_reference<>())  )
+        	  .add_property("names",
+        			bp::make_function(&ModelPythonVisitor::names,
+        					  bp::return_internal_reference<>())  )
+        	  .add_property("gravity",&ModelPythonVisitor::gravity,&ModelPythonVisitor::setGravity)
+
+        	  .def("BuildEmptyModel",&ModelPythonVisitor::maker_empty)
+        	  .staticmethod("BuildEmptyModel")
+        	  .def("BuildHumanoidSimple",&ModelPythonVisitor::maker_humanoidSimple)
+        	  .staticmethod("BuildHumanoidSimple")*/
+        ;
+    }
+///suboptimal (store joint id yourself)
+    static int getJointID(  const RobotUpdateHandler & modelPtr,const std::string&name  )
+    {
+        graphics::Robot::Joints::const_iterator it;
+        int cpt=0;
+        for(it=modelPtr ->getRobot()->getJoints().begin();
+                it!=modelPtr ->getRobot()->getJoints().end()&& (*it)->getName()!=name; it++)cpt++;
+        if(      it!=modelPtr ->getRobot()->getJoints().end())return cpt;
+        else return -1;
+    }
+
+ static void setDebugCollisionOnOff (   RobotUpdateHandler & modelPtr  )
+    {
+        //write model is
+        //not thread safe   return modelPtr ->getRobot()->setUrdfFile(name); is wrong
+        //so
+        modelPtr ->addOrder(
+            new SwitchDebugOrder(*modelPtr ->getRobot() ));
+    }
+    static void setUrdfFile (    RobotUpdateHandler & modelPtr,const std::string&name  )
+    {
+        //write model is
+        //not thread safe   return modelPtr ->getRobot()->setUrdfFile(name); is wrong
+        //so
+        modelPtr ->addOrder(
+            new SetUrdfFileOrder(*modelPtr ->getRobot(),name));
+    }
+
+    static void setUrdfPackageDirectory (    RobotUpdateHandler & modelPtr,const std::string&name  )
+    {
+        //write model is
+        //not thread safe   return modelPtr ->getRobot()->setUrdfFile(name); is wrong
+        //so
+        modelPtr ->addOrder(
+            new SetUrdfPackageDirectoryOrder(*modelPtr ->getRobot(),name));
+    }
+      static void setJointConfiguration(   RobotUpdateHandler & modelPtr,int osgjointid, const se3::SE3::Quaternion & q )
+    {
+        return  modelPtr ->addOrder(
+                    new UpdateJointOrder(*modelPtr ->getRobot()->getJoints()[osgjointid],
+                                         osg::Vec3(0,0,0),///always null...:/
+                                         osg::Quat(q.coeffs().x(),q.coeffs().y(),q.coeffs().z(),q.coeffs().w())));
+    }
+
+    /*  static boost::shared_ptr<Data> createData(const ModelHandler& m )
+      {	return boost::shared_ptr<Data>( new Data(*m) );      }
+
+      static int nq( ModelHandler & m ) { return m->nq; }
+      static int nv( ModelHandler & m ) { return m->nv; }
+      static int nbody( ModelHandler & m ) { return m->nbody; }
+      static std::vector<Inertia> & inertias( ModelHandler & m ) { return m->inertias; }
+      static std::vector<SE3> & jointPlacements( ModelHandler & m ) { return m->jointPlacements; }
+      static std::vector<Model::Index> & parents( ModelHandler & m ) { return m->parents; }
+      static std::vector<std::string> & names ( ModelHandler & m ) { return m->names; }
+      static Motion gravity( ModelHandler & m ) { return m->gravity; }
+      static void setGravity( ModelHandler & m,const Motion_fx & g ) { m->gravity = g; }
+    */
+    static RobotUpdateHandler maker_empty()
+    {
+        RobotUpdate* ru=new RobotUpdate();
+        return RobotUpdateHandler(  ru,true );
+    }
+    /*static ModelHandler maker_humanoidSimple()
+    {
+    Model * model = new Model();
+    buildModels::humanoidSimple(*model);
+    return ModelHandler( model,true );
+         }
+    */
+    static std::string toString(const RobotUpdateHandler& m)
+    {
+        std::ostringstream s;
+        s <<*(unsigned*) (&m. get());
+        return s.str();
+    }
+
+    /* --- Expose --------------------------------------------------------- */
+    static void expose()
+    {
+        bp::class_< std::vector<int> >("StdVec_int")
+        .def(bp::vector_indexing_suite< std::vector<int> >());
+        bp::class_< std::vector<std::string> >("StdVec_StdString")
+        .def(bp::vector_indexing_suite< std::vector<std::string> >());
+
+        bp::class_<RobotUpdateHandler>("RobotUpdate",
+                                       "Visual Controller for Articulated rigid body model (const)",
+                                       bp::no_init)
+        .def(RobotUpdatePythonVisitor());
+
+        /* Not sure if it is a good idea to enable automatic
+         * conversion. Prevent it for now */
+        //bp::to_python_converter< Model,ModelPythonVisitor >();
+        bp::to_python_converter< RobotUpdateHandler::SmartPtr_t,RobotUpdatePythonVisitor >();
+    }
+
+
+};
+
+
+
+}
+} // namespace se3::python
+
+#endif // ifndef __se3_python_model_hpp__
+

--- a/include/gepetto/python/graphicrobot.hpp
+++ b/include/gepetto/python/graphicrobot.hpp
@@ -84,12 +84,14 @@ public:
 ///suboptimal (store joint id yourself)
     static int getJointID(  const RobotUpdateHandler & modelPtr,const std::string&name  )
     {
+     modelPtr-> beginSyncCall();
         graphics::Robot::Joints::const_iterator it;
         int cpt=0;
         for(it=modelPtr ->getRobot()->getJoints().begin();
                 it!=modelPtr ->getRobot()->getJoints().end()&& (*it)->getName()!=name; it++)cpt++;
-        if(      it!=modelPtr ->getRobot()->getJoints().end())return cpt;
-        else return -1;
+        if(      it==modelPtr ->getRobot()->getJoints().end()) cpt=-1;
+     modelPtr-> endSyncCall();
+          return cpt;
     }
 
     static void setDebugCollisionOnOff (   RobotUpdateHandler & modelPtr  )

--- a/include/gepetto/python/graphicviewer.hpp
+++ b/include/gepetto/python/graphicviewer.hpp
@@ -1,0 +1,187 @@
+#ifndef __se3_python_visualviewer_hpp__
+#define __se3_python_visualviewer_hpp__
+
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <eigenpy/exception.hpp>
+#include <eigenpy/eigenpy.hpp>
+
+#include <gepetto/viewer/viewer.h>
+
+#include <pinocchio/python/motion.hpp>
+#include "gepetto/python/graphicrobot.hpp"
+
+#include <OpenThreads/Thread>
+
+
+
+
+
+
+namespace graphics
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+
+    template<typename RobotViewer>
+    struct RobotViewerPythonVisitor
+      : public boost::python::def_visitor< RobotViewerPythonVisitor<RobotViewer> >
+    {
+    /*  typedef typename RobotViewer::Force Force;
+      typedef typename RobotViewer::Matrix3 Matrix3;
+      typedef typename RobotViewer::Matrix6 Matrix6;
+      typedef typename RobotViewer::Vector6 Vector6;
+      typedef typename RobotViewer::Vector3 Vector3;
+
+      typedef typename eigenpy::UnalignedEquivalent<RobotViewer>::type RobotViewer_fx;
+      typedef typename RobotViewer_fx::Force Force_fx;
+      typedef typename RobotViewer_fx::Matrix3 Matrix3_fx;
+      typedef typename RobotViewer_fx::Matrix6 Matrix6_fx;
+      typedef typename RobotViewer_fx::Vector6 Vector6_fx;
+      typedef typename RobotViewer_fx::Vector3 Vector3_fx;*/
+typedef  RobotViewer   RobotViewer_fx;
+    public:
+
+      static PyObject* convert(RobotViewer const& m)
+      {
+	RobotViewer_fx m_fx ;//=(RobotViewer*)&m;
+	return boost::python::incref(boost::python::object(m_fx).ptr());
+      }
+
+      template<class PyClass>
+      void visit(PyClass& cl) const
+      {
+	cl
+	/*  .def(bp::init<>(/*<Vector3_fx,Vector3_fx>
+	       ((bp::arg("linear"),bp::arg("angular")
+
+		"Initialize the viewer"))*/
+
+		//.def("RobotViewer",*maker_empty())
+		.def("addNewRobot",&RobotViewerPythonVisitor::addNewRobot)
+		.def("start",&RobotViewerPythonVisitor::start)
+		.def("stop",&RobotViewerPythonVisitor::stop)
+	 // .def("createData",&RobotViewerPythonVisitor::createData)
+
+	  .def("__str__",& RobotViewerPythonVisitor::toString)
+	 /* .def(bp::init<Vector6_fx>((bp::arg("Vector 6d")),"Init from vector 6 [f,n]"))
+
+	  .add_property("linear",&RobotViewerPythonVisitor::getLinear,&RobotViewerPythonVisitor::setLinear)
+	  .add_property("angular",&RobotViewerPythonVisitor::getAngular,&RobotViewerPythonVisitor::setAngular)
+	  .def("vector",&RobotViewer_fx::toVector)
+	  .def("se3Action",&RobotViewer_fx::se3Action)
+	  .def("se3ActionInverse",&RobotViewer_fx::se3ActionInverse)
+
+	  .def("cross_motion",&RobotViewerPythonVisitor::cross_motion)
+	  .def("cross_force",&RobotViewerPythonVisitor::cross_force)
+
+	  .def("__str__",&RobotViewerPythonVisitor::toString)
+	  .add_property("np",&RobotViewer_fx::toVector)
+
+	  .def("Random",&RobotViewer_fx::Random)
+	  .staticmethod("Random")
+	  .def("Zero",&RobotViewer_fx::Zero)
+	  .staticmethod("Zero")*/
+	  ;
+	  }
+
+  /*    static Vector3_fx getLinear( const RobotViewer_fx & self ) { return self.linear(); }
+      static void setLinear( RobotViewer_fx & self, const Vector3_fx & R ) { self.linear(R); }
+      static Vector3_fx getAngular( const RobotViewer_fx & self ) { return self.angular(); }
+      static void setAngular( RobotViewer_fx & self, const Vector3_fx & R ) { self.angular(R); }
+
+      static RobotViewer_fx cross_motion( const RobotViewer_fx& m1,const RobotViewer_fx& m2 ) { return m1.cross(m2); }
+      static Force_fx cross_force( const RobotViewer_fx& m,const Force_fx& f ) { return m.cross(f); }
+
+      static std::string toString(const RobotViewer_fx& m)
+      {	  std::ostringstream s; s << m; return s.str();       }
+
+      static void expose()
+      {
+	bp::class_<RobotViewer_fx>("RobotViewer",
+			     "RobotViewer vectors, in se3* == F^6.\n\n"
+			     "Supported operations ...",
+			     bp::init<>())
+	  .def(RobotViewerPythonVisitor<RobotViewer>())
+	;
+
+	bp::to_python_converter< RobotViewer,RobotViewerPythonVisitor<RobotViewer> >();
+    }*/
+  static RobotUpdateHandler addNewRobot(   RobotViewer_fx & modelPtr )
+      { RobotUpdate* ru=modelPtr .createRobot();
+      return  RobotUpdateHandler(ru,true);
+}
+  static void start(   RobotViewer_fx & modelPtr )
+      { modelPtr.start();
+}
+
+  static void stop(   RobotViewer_fx & modelPtr )
+      { modelPtr.stop();
+}
+
+    /*  static boost::shared_ptr<Data> createData(const ModelHandler& m )
+      {	return boost::shared_ptr<Data>( new Data(*m) );      }
+
+      static int nq( ModelHandler & m ) { return m->nq; }
+      static int nv( ModelHandler & m ) { return m->nv; }
+      static int nbody( ModelHandler & m ) { return m->nbody; }
+      static std::vector<Inertia> & inertias( ModelHandler & m ) { return m->inertias; }
+      static std::vector<SE3> & jointPlacements( ModelHandler & m ) { return m->jointPlacements; }
+      static std::vector<Model::Index> & parents( ModelHandler & m ) { return m->parents; }
+      static std::vector<std::string> & names ( ModelHandler & m ) { return m->names; }
+      static RobotViewer gravity( ModelHandler & m ) { return m->gravity; }
+      static void setGravity( ModelHandler & m,const RobotViewer_fx & g ) { m->gravity = g; }
+*/
+static osg::ref_ptr<RobotViewer>  singleton;
+      static RobotViewer_fx* maker_empty()
+      {
+      if(!singleton.valid()){
+      OpenThreads::Thread::Init();
+      singleton=new RobotViewer();
+        std::cerr<<"realized"<<std::endl;
+      }
+        std::cerr<<"realized"<<std::endl;
+      singleton->start();
+	return  singleton.get();//RobotViewerHandler( new RobotViewer(),true );
+      }
+      /*static ModelHandler maker_humanoidSimple()
+      {
+	Model * model = new Model();
+	buildModels::humanoidSimple(*model);
+	return ModelHandler( model,true );
+      }
+*/
+      static std::string toString(const RobotViewer_fx& m)
+      {	  std::ostringstream s; s <<*(unsigned*)  (&m  ); return s.str();       }
+
+      /* --- Expose --------------------------------------------------------- */
+      static void expose()
+      {  OpenThreads::Thread::Init();
+        std::cerr<<"OpenThreads::Thread::Init"<<std::endl;
+	bp::class_< std::vector<int> >("StdVec_int")
+	  .def(bp::vector_indexing_suite< std::vector<int> >());
+	bp::class_< std::vector<std::string> >("StdVec_StdString")
+	  .def(bp::vector_indexing_suite< std::vector<std::string> >());
+bp::class_<RobotViewer_fx, boost::noncopyable>("RobotViewer")
+/*	bp::class_<RobotViewer_fx>("RobotViewer",
+				 "osg::CompositeViewer wrapped for specialized usage (const)" ,
+				    bp::init<>()) //bp::no_init)*/
+	  .def(RobotViewerPythonVisitor())
+	 // .def(maker_empty())
+	  ;
+
+	/* Not sure if it is a good idea to enable automatic
+	 * conversion. Prevent it for now */
+	//bp::to_python_converter< Model,ModelPythonVisitor >();
+	bp::to_python_converter< RobotViewer ,RobotViewerPythonVisitor <RobotViewer > >();
+      }
+
+
+    };
+
+
+
+  }} // namespace se3::python
+
+
+#endif // ifndef __se3_python_model_hpp__

--- a/include/gepetto/python/handler.hpp
+++ b/include/gepetto/python/handler.hpp
@@ -1,0 +1,76 @@
+#ifndef __se3_python_handler_hpp__
+#define __se3_python_handler_hpp__
+
+#include <boost/shared_ptr.hpp>
+
+namespace graphics
+{
+  namespace python
+  {
+
+    /* This handler is designed first for holding the C++ Model object, then
+     * generalized for the C++ Data object. It might be used as well for
+     * handling other object whose ownership is shared between python and C++.
+     *
+     * There might be several way of building and owning a model object:
+     *   - build from C++ (as static or dynamic, wathever), and owned by
+     * C++. In that case, use a ModelHandler with no ownership ModelHandler(
+     * Model*,false).
+     *   - build from C++ but owned by python. Python would be in charge of
+     * destroying it when it is done. In that case, use
+     * ModelHandler(Model*,true). Take care not to destroy the object by
+     * yourself, otherwise there might have access to deallocated memory and
+     * double destruction.
+     *   - build and managed by shared_ptr. It is the best way, in the sense
+     * that the object is manage both by C++ and python. It will be released
+     * only when both are done with it.  In that case, simply give Python the
+     * shared_ptr ModelHandler( shared_ptr<Model> ).
+     *
+     * It is not possible to construct a Model from python, because of Eigen
+     * memory alignement.  The python visitor does not define any
+     * constructor. Instead, some static makers (function allocating memory and
+     * returning a pointer Model *) are implemented.  When Python is making
+     * such a Model, it is stored in a shared_ptr and can be access directly
+     * from C++. By default, when passing a Model to python, it is kept as a
+     * raw pointer. Access is then done from python to the C++ memory without
+     * any guarantee. If you want to enforce memory access, prefer transmitting
+     * a shared_ptr to python.
+     */
+    template<typename CppObject>
+    struct Handler
+    {
+      typedef boost::shared_ptr<CppObject> SmartPtr_t;
+      typedef CppObject * Ptr_t;
+
+      SmartPtr_t smptr;
+      Ptr_t rawptr;
+      bool smart;
+
+      Handler(CppObject * cppobj,bool transmitOwnership=false)
+	: smptr( transmitOwnership ? cppobj : NULL )
+	, rawptr( cppobj )
+	, smart( transmitOwnership ) {}
+      Handler( SmartPtr_t cppobj )
+	: smptr(cppobj), rawptr(NULL), smart(true) {}
+      ~Handler()
+      {
+	//std::cout << "Destroy cppobj handler " << std::endl;
+	if( (!smart) && (rawptr!=NULL) ) delete rawptr;
+      }
+
+      CppObject *       ptr()              { return smart ?  smptr.get() :  rawptr; }
+      const CppObject * ptr()        const { return smart ?  smptr.get() :  rawptr; }
+      CppObject *       operator->()       { return ptr(); }
+      const CppObject * operator->() const { return ptr(); }
+
+      CppObject &       get()              { return smart ? *smptr       : *rawptr; }
+      const CppObject & get()        const { return smart ? *smptr       : *rawptr; }
+      CppObject &       operator*()        { return get(); }
+      const CppObject&  operator*()  const { return get(); }
+    };
+
+
+  }} // namespace se3::python
+
+#endif // ifndef __se3_python_handler_hpp__
+

--- a/include/gepetto/python/python.hpp
+++ b/include/gepetto/python/python.hpp
@@ -1,0 +1,20 @@
+#ifndef __se3_python_python_hpp__
+#define __se3_python_python_hpp__
+
+namespace graphics
+{
+  namespace python
+  {
+    void exposeRobotUpdate();
+    void exposeRobotViewer();
+/*    void exposeMotion();
+    void exposeInertia();
+
+    void exposeModel();
+    void exposeAlgorithms();
+    void exposeParsers();
+*/
+  }} // namespace se3::python
+
+#endif // ifndef __se3_python_python_hpp__
+

--- a/include/gepetto/viewer/robot.h
+++ b/include/gepetto/viewer/robot.h
@@ -21,11 +21,18 @@ public:
         this->_urdfmodel=rhs._urdfmodel;
     }
 
+
     Link(const Link&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::Group(rhs,  copyop) {}
     META_Node(graphics, Link);
-    urdf::Link *getUrdfModel()
+
+    ///Properties
+    inline const urdf::Link *getUrdfModel()const
     {
         return _urdfmodel.get() ;
+    }
+    inline void setUrdfModel(boost::shared_ptr<urdf::Link > &l)
+    {
+        _urdfmodel=l ;
     }
 };
 
@@ -43,9 +50,14 @@ public:
 
     Joint(const Joint&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::MatrixTransform(rhs,  copyop) {}
     META_Node(graphics, Joint);
-    urdf::Joint *getUrdfModel()
+    ///Properties
+    inline const urdf::Joint *getUrdfModel()const
     {
         return _urdfmodel.get() ;
+    }
+    inline void setUrdfModel(boost::shared_ptr<urdf::Joint >&l)
+    {
+        _urdfmodel=l ;
     }
 };
 
@@ -55,6 +67,7 @@ class Robot:public osg::Group
 public:
 
     Robot();
+
     Robot(const Robot&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY) :osg::Group(rhs,  copyop) {}
     META_Node(graphics, Robot);
 
@@ -83,23 +96,26 @@ public:
     }
     Joint *getOsgJoint(boost::shared_ptr<urdf::Joint >j) ;
     Link *getOsgLink(boost::shared_ptr<urdf::Link >j);
-    //void getOsgJoint(JointIndex i){return }
-    bool parse (boost::shared_ptr<urdf::Link > &link);
-    ///SE3Model.addBody (if DOF) + osg::Transform creation
-    bool  parse (boost::shared_ptr<urdf::Joint > &link);
+
 
 protected:
-    osg::ref_ptr<osg::Node> _debugaxes;
+    ///Meshes loading
+    virtual bool parse (boost::shared_ptr<urdf::Link > &link);
+    ///SE3Model.addBody (if DOF) + osg::Transform creation
+    virtual bool  parse (boost::shared_ptr<urdf::Joint > &link);
+    ~Robot();
+    osg::ref_ptr<osg::Node> _debugaxes; ///
     std::string _urdfPackageRootDirectory;
     se3::Model *SE3Model;
-    //linear inner index
-    typedef unsigned int LinkIndex;
-    typedef unsigned int JointIndex;
+
 protected:
     ///classic async model
     ///typedef std::tuple<urdf::Model *,osg::Model,SE3::Model,...> ModelstoSync
     ///choice done: urdf as entry point and maintain with dirtyflag and use osg update callback to sync models
     ///store local reference to joint and link for direct memory access
+    /// inner indexes
+    typedef unsigned int LinkIndex;
+    typedef unsigned int JointIndex;
     std::vector<boost::shared_ptr<urdf::Link > > _links;
     std::vector<osg::ref_ptr<Link > > _osglinks;
     std::map< urdf::Link *,LinkIndex  > _invLinksMap;

--- a/include/gepetto/viewer/robot.h
+++ b/include/gepetto/viewer/robot.h
@@ -1,0 +1,113 @@
+#ifndef OSGROBOT_H
+#define OSGROBOT_H
+
+
+#include <urdf_model/model.h>
+#include <osg/PositionAttitudeTransform>
+namespace se3
+{
+class Model;
+}
+namespace graphics
+{
+class Link:public osg::Group
+{
+protected:
+    boost::shared_ptr<urdf::Link > _urdfmodel;
+public:
+    Link(): osg::Group() {}
+    Link(const Link&rhs)
+    {
+        this->_urdfmodel=rhs._urdfmodel;
+    }
+
+    Link(const Link&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::Group(rhs,  copyop) {}
+    META_Node(graphics, Link);
+    urdf::Link *getUrdfModel()
+    {
+        return _urdfmodel.get() ;
+    }
+};
+
+
+class Joint:public osg::PositionAttitudeTransform
+{
+protected:
+    boost::shared_ptr<urdf::Joint > _urdfmodel;
+public:
+    Joint() :osg::PositionAttitudeTransform() {}
+    Joint(const Joint&rhs)
+    {
+        this->_urdfmodel=rhs._urdfmodel;
+    }
+
+    Joint(const Joint&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::PositionAttitudeTransform(rhs,  copyop) {}
+    META_Node(graphics, Joint);
+    urdf::Joint *getUrdfModel()
+    {
+        return _urdfmodel.get() ;
+    }
+};
+
+class Robot:public osg::Group
+{
+
+public:
+
+    Robot(): osg::Group(),_debugaxes(0) {}
+    Robot(const Robot&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY) :osg::Group(rhs,  copyop) {}
+    META_Node(graphics, Robot);
+
+    se3::Model * getSE3Model()const
+    {
+        return SE3Model;
+    }
+
+    void setUrdfPackageRootDirectory(const std::string & s)
+    {
+        _urdfPackageRootDirectory=s;
+    }
+    const std::string & getUrdfPackageRootDirectory()const
+    {
+        return _urdfPackageRootDirectory ;
+    }
+
+
+    void addLink(boost::shared_ptr<urdf::Link > &link)
+    {
+        parse(link);
+    }
+    void addJoint(boost::shared_ptr<urdf::Joint > &link)
+    {
+        parse(link);
+    }
+    Joint *getOsgJoint(boost::shared_ptr<urdf::Joint >j) ;
+    Link *getOsgLink(boost::shared_ptr<urdf::Link >j);
+    //void getOsgJoint(JointIndex i){return }
+    bool parse (boost::shared_ptr<urdf::Link > &link);
+    ///SE3Model.addBody (if DOF) + osg::Transform creation
+    bool  parse (boost::shared_ptr<urdf::Joint > &link);
+
+protected:
+    osg::ref_ptr<osg::Node> _debugaxes;
+    std::string _urdfPackageRootDirectory;
+    se3::Model *SE3Model;
+    //linear inner index
+    typedef unsigned int LinkIndex;
+    typedef unsigned int JointIndex;
+protected:
+    ///classic async model
+    ///typedef std::tuple<urdf::Model *,osg::Model,SE3::Model,...> ModelstoSync
+    ///choice done: urdf as entry point and maintain with dirtyflag and use osg update callback to sync models
+    ///store local reference to joint and link for direct memory access
+    std::vector<boost::shared_ptr<urdf::Link > > _links;
+    std::vector<osg::ref_ptr<Link > > _osglinks;
+    std::map< urdf::Link *,LinkIndex  > _invLinksMap;
+
+    std::vector<boost::shared_ptr<urdf::Joint > > _joints;
+    std::vector<osg::ref_ptr<Joint > > _osgjoints;
+    std::map< urdf::Joint *,JointIndex  > _invJointsMap;
+
+};
+}
+#endif

--- a/include/gepetto/viewer/robot.h
+++ b/include/gepetto/viewer/robot.h
@@ -16,6 +16,10 @@ protected:
     boost::shared_ptr<urdf::Link > _urdfmodel;
 public:
     Link(): osg::Group() {}
+    Link(boost::shared_ptr<urdf::Link >&l) :osg::Group()
+    {
+        _urdfmodel=l;
+    }
     Link(const Link&rhs)
     {
         this->_urdfmodel=rhs._urdfmodel;
@@ -42,7 +46,11 @@ class Joint:public osg::MatrixTransform
 protected:
     boost::shared_ptr<urdf::Joint > _urdfmodel;
 public:
-    Joint() :osg::MatrixTransform() {}
+    Joint() :osg::MatrixTransform(){    }
+    Joint(boost::shared_ptr<urdf::Joint >&l) :osg::MatrixTransform()
+    {
+        _urdfmodel=l;
+    }
     Joint(const Joint&rhs)
     {
         this->_urdfmodel=rhs._urdfmodel;

--- a/include/gepetto/viewer/robot.h
+++ b/include/gepetto/viewer/robot.h
@@ -3,7 +3,7 @@
 
 
 #include <urdf_model/model.h>
-#include <osg/PositionAttitudeTransform>
+#include <osg/MatrixTransform>
 namespace se3
 {
 class Model;
@@ -30,18 +30,18 @@ public:
 };
 
 
-class Joint:public osg::PositionAttitudeTransform
+class Joint:public osg::MatrixTransform
 {
 protected:
     boost::shared_ptr<urdf::Joint > _urdfmodel;
 public:
-    Joint() :osg::PositionAttitudeTransform() {}
+    Joint() :osg::MatrixTransform() {}
     Joint(const Joint&rhs)
     {
         this->_urdfmodel=rhs._urdfmodel;
     }
 
-    Joint(const Joint&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::PositionAttitudeTransform(rhs,  copyop) {}
+    Joint(const Joint&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY):osg::MatrixTransform(rhs,  copyop) {}
     META_Node(graphics, Joint);
     urdf::Joint *getUrdfModel()
     {
@@ -54,7 +54,7 @@ class Robot:public osg::Group
 
 public:
 
-    Robot(): osg::Group(),_debugaxes(0) {}
+    Robot();
     Robot(const Robot&rhs,const osg::CopyOp& copyop=osg::CopyOp::SHALLOW_COPY) :osg::Group(rhs,  copyop) {}
     META_Node(graphics, Robot);
 

--- a/include/gepetto/viewer/robot.h
+++ b/include/gepetto/viewer/robot.h
@@ -230,7 +230,9 @@ protected:
     std::vector<boost::shared_ptr<urdf::Joint > > _joints;
     std::vector<osg::ref_ptr<Joint > > _osgjoints;
     std::map< urdf::Joint *,JointIndex  > _invJointsMap;
-
+private:
+///local helper generate an osg Group from a ::urdf::Mesh
+osg::MatrixTransform * getGeometryNode( boost::shared_ptr<  urdf::Geometry > &);
 };
 
 ///ThreadSafe Order for RobotUpdateCallback

--- a/include/gepetto/viewer/urdf-parser.h
+++ b/include/gepetto/viewer/urdf-parser.h
@@ -9,10 +9,7 @@
 #ifndef SCENEVIEWER_URDFPARSER_HH
 #define SCENEVIEWER_URDFPARSER_HH
 
-#include <urdf_model/model.h>
-#include <urdf_parser/urdf_parser.h>
-#include <gepetto/viewer/group-node.h>
-#include <gepetto/viewer/leaf-node-collada.h>
+#include <gepetto/viewer/robot.h>
 
 namespace graphics {
   namespace urdfParser {
@@ -25,19 +22,11 @@ namespace graphics {
     /// \param meshDataRootDir path to the package that contains the collada
     ///                        files,
     ///                        i.e. "/opt/ros/hydro/share/"
-    /// \param collisionOrVisual whether to parse the visual part or the
-    ///        collision part of links.
-    /// \param linkOrObjectFrame in the urdf kinematic chain, objects are
-    ///        rigidly attached to a link. This parameter determines whether
-    ///        the node frame corresponds to the link frame or to the object
-    ///        frame.
     /// \note the parser will replace "package://" by meshDataRootDir in the
     ///       urdf file.
-    GroupNodePtr_t parse (const std::string& robotName,
+    Robot* parse (const std::string& robotName,
 			  const std::string& urdf_file_path,
-			  const std::string& meshDataRootDir,
-			  const std::string& collisionOrVisual = "visual",
-			  const std::string& linkOrObjectFrame = "link");
+			  const std::string& meshDataRootDir);
 
   }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 SET(LIBRARY_NAME ${PROJECT_NAME})
 find_package(OpenSceneGraph REQUIRED)
-find_package(osgGA REQUIRED) 
+find_package(osgGA REQUIRED)
 find_package(osgDB REQUIRED)
 find_package(osgViewer REQUIRED)
 
@@ -38,6 +38,7 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
   #leaf-node-collada.cpp
   urdf-parser.cpp
 robot.cpp
+viewer.cpp
 )
 include_directories(${PINOCCHIO_PATH}/include)
 include_directories(${EIGEN3_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,30 +18,36 @@
 # <http://www.gnu.org/licenses/>.
 
 SET(LIBRARY_NAME ${PROJECT_NAME})
+find_package(OpenSceneGraph REQUIRED)
+find_package(osgGA REQUIRED) 
+find_package(osgDB REQUIRED)
+find_package(osgViewer REQUIRED)
 
 ADD_LIBRARY(${LIBRARY_NAME} SHARED
-  group-node.cpp
-  node.cpp
-  window-manager.cpp
-  leaf-node-line.cpp
-  leaf-node-box.cpp
-  leaf-node-cylinder.cpp
-  leaf-node-cone.cpp
-  leaf-node-face.cpp
-  leaf-node-sphere.cpp
-  leaf-node-capsule.cpp
-  leaf-node-ground.cpp
-  leaf-node-collada.cpp
+ # group-node.cpp
+  #node.cpp
+  #window-manager.cpp
+  #leaf-node-line.cpp
+  #leaf-node-box.cpp
+  #leaf-node-cylinder.cpp
+  #leaf-node-cone.cpp
+  #leaf-node-face.cpp
+ # leaf-node-sphere.cpp
+  #leaf-node-capsule.cpp
+  #leaf-node-ground.cpp
+  #leaf-node-collada.cpp
   urdf-parser.cpp
+robot.cpp
 )
-
+include_directories(${PINOCCHIO_PATH}/include)
+include_directories(${EIGEN3_INCLUDE_DIR})
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} openscenegraph)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} openthreads)
 #PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} eigen3)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} urdfdom)
 
 ADD_EXECUTABLE(testing ../tests/test.cpp)
-TARGET_LINK_LIBRARIES(testing ${LIBRARY_NAME})
+TARGET_LINK_LIBRARIES(testing ${LIBRARY_NAME} ${OPENTHREADS_LIBRARIES}  ${OPENSCENEGRAPH_LIBRARIES} ${OSGVIEWER_LIBRARIES} ${OSGDB_LIBRARIES} ${OSGGA_LIBRARIES})
 INSTALL(TARGETS testing DESTINATION bin)
 
 INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION lib)

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -1,0 +1,32 @@
+#include <eigenpy/eigenpy.hpp>
+/*#include <eigenpy/eigenpy.hpp>
+#include <eigenpy/geometry.hpp>*/
+#include "gepetto/python/python.hpp"
+
+#include <iostream>
+
+namespace bp = boost::python;
+
+BOOST_PYTHON_MODULE(libgepetto_pywrap)
+{
+  /*eigenpy::enableEigenPy();
+  eigenpy::exposeAngleAxis();
+  eigenpy::exposeQuaternion();
+
+  typedef Eigen::Matrix<double,6,6> Matrix6d;
+  typedef Eigen::Matrix<double,6,1> Vector6d;
+
+  eigenpy::enableEigenPySpecific<Matrix6d,Matrix6d>();
+  eigenpy::enableEigenPySpecific<Vector6d,Vector6d>();*/
+
+  graphics::python::exposeRobotUpdate();
+ graphics::python::exposeRobotViewer();
+/*  se3::python::exposeForce();
+  se3::python::exposeMotion();
+  se3::python::exposeInertia();
+
+  se3::python::exposeModel();
+  se3::python::exposeAlgorithms();
+  se3::python::exposeParsers();*/
+}
+

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -1,6 +1,6 @@
 #include <eigenpy/eigenpy.hpp>
-/*#include <eigenpy/eigenpy.hpp>
-#include <eigenpy/geometry.hpp>*/
+#include <eigenpy/eigenpy.hpp>
+#include <eigenpy/geometry.hpp>
 #include "gepetto/python/python.hpp"
 
 #include <iostream>
@@ -9,10 +9,10 @@ namespace bp = boost::python;
 
 BOOST_PYTHON_MODULE(libgepetto_pywrap)
 {
-  /*eigenpy::enableEigenPy();
+ eigenpy::enableEigenPy();
   eigenpy::exposeAngleAxis();
   eigenpy::exposeQuaternion();
-
+ /*
   typedef Eigen::Matrix<double,6,6> Matrix6d;
   typedef Eigen::Matrix<double,6,1> Vector6d;
 

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -1,0 +1,52 @@
+#include "pinocchio/python/python.hpp"
+/*#include "pinocchio/python/se3.hpp"
+#include "pinocchio/python/force.hpp"
+#include "pinocchio/python/motion.hpp"
+#include "pinocchio/python/inertia.hpp"
+
+#include "pinocchio/python/model.hpp"
+#include "pinocchio/python/data.hpp"
+#include "pinocchio/python/algorithms.hpp"*/
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include "gepetto/python/graphicrobot.hpp"
+#include "gepetto/python/graphicviewer.hpp"
+
+namespace graphics
+{
+  namespace python
+  {
+    void exposeRobotUpdate()
+    {
+      RobotUpdatePythonVisitor::expose();
+    //  PyWraperForAlignedStdVector<SE3>::expose("StdVect_RobotUpdate"); //PATE?
+    }
+    void exposeRobotViewer()
+    {
+      RobotViewerPythonVisitor<RobotViewer>::expose();
+    //  ForcePythonVisitor<Force>::expose();
+     // PyWraperForAlignedStdVector<Force>::expose("StdVec_RobotViewer");
+    }
+  /* void exposeMotion()
+    {
+      MotionPythonVisitor<Motion>::expose();
+      PyWraperForAlignedStdVector<Motion>::expose("StdVec_Motion");
+    }
+    void exposeInertia()
+    {
+      InertiaPythonVisitor<Inertia>::expose();
+      PyWraperForAlignedStdVector<Inertia>::expose("StdVec_Inertia");
+    }
+    void exposeModel()
+    {
+      ModelPythonVisitor::expose();
+      DataPythonVisitor::expose();
+    }
+    void exposeAlgorithms()
+    {
+      AlgorithmsPythonVisitor::expose();
+    }
+    void exposeParsers()
+    {
+      ParsersPythonVisitor::expose();
+    }*/
+  }} // namespace se3::python

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -27,7 +27,7 @@ bool Robot::parse (boost::shared_ptr<urdf::Link > &link)
 {
     osg::ref_ptr<Link> lastone=0,newone=0;
     lastone=getOsgLink(link  );
-    if(!lastone.valid())newone=new Link();
+    if(!lastone.valid())newone=new Link(link);
     else return true;//don't update previous ...newone=lastone;//update previous version
     osg::ref_ptr<Joint> child=0,parent=0;
     if(link->parent_joint)
@@ -108,11 +108,11 @@ bool Robot::parse (boost::shared_ptr<urdf::Link > &link)
     }
 }
 ///SE3Model.addBody (if DOF) + osg::Transform creation
-bool Robot::parse (boost::shared_ptr<urdf::Joint > &link)
+bool Robot::parse (boost::shared_ptr<urdf::Joint > &joint)
 {
     osg::ref_ptr<Joint> lastone=0,newone=0;
-    lastone=getOsgJoint(link  );
-    if(!lastone.valid())newone=new Joint();
+    lastone=getOsgJoint(joint  );
+    if(!lastone.valid())newone=new Joint(joint);
     else return true;//don't update previous ...newone=lastone;//update previous version
 
 
@@ -124,24 +124,24 @@ bool Robot::parse (boost::shared_ptr<urdf::Joint > &link)
 ///set osg model
     osg::Matrixf m;
     m.setTrans(osg::Vec3(
-                   (float)link->parent_to_joint_origin_transform.position.x,
-                   (float)link->parent_to_joint_origin_transform.position.y,
-                   (float)link->parent_to_joint_origin_transform.position.z
+                   (float)joint->parent_to_joint_origin_transform.position.x,
+                   (float)joint->parent_to_joint_origin_transform.position.y,
+                   (float)joint->parent_to_joint_origin_transform.position.z
                ));
     m.setRotate(osg::Quat(
-                    (float)link->parent_to_joint_origin_transform.rotation.x,
-                    (float)link->parent_to_joint_origin_transform.rotation.y,
-                    (float)link->parent_to_joint_origin_transform.rotation.z,
-                    (float)link->parent_to_joint_origin_transform.rotation.w
+                    (float)joint->parent_to_joint_origin_transform.rotation.x,
+                    (float)joint->parent_to_joint_origin_transform.rotation.y,
+                    (float)joint->parent_to_joint_origin_transform.rotation.z,
+                    (float)joint->parent_to_joint_origin_transform.rotation.w
                 ));
     newone->setMatrix(m);
 
-    newone->setName(link->name);
+    newone->setName(joint->name);
     if(!lastone.valid())
     {
 ///actual add to model
-        _invJointsMap[link.get()]=_joints.size();
-        _joints.push_back(link);
+        _invJointsMap[joint.get()]=_joints.size();
+        _joints.push_back(joint);
         _osgjoints.push_back(newone);
     }
     return true;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -8,6 +8,10 @@ Robot::Robot(): osg::Group(),_debugaxes(0)
     SE3Model=new se3::Model();
 }
 
+Robot::~Robot()
+{
+    delete SE3Model;
+}
 Link *Robot::getOsgLink(boost::shared_ptr<urdf::Link >j)
 {
     std::map< urdf::Link *,LinkIndex  >::iterator it= _invLinksMap.find(j.get());

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -235,6 +235,40 @@ bool Robot::parse (boost::shared_ptr<urdf::Link > &link)
     return true;
 
 }
+void Joint::applyConfiguration(const se3::SE3 &conf)//const osg::Vec3&v,const osg::Quat&q)
+{
+    se3::SE3::Matrix4 m=conf.toHomogeneousMatrix();
+    // osg::Matrixd m;
+    osg::Matrixd  M (
+        m(0,0),m(0,1),m(0,2),m(0,3),
+        m(1,0),m(1,1),m(1,2) ,m(1,3),
+        m(2,0),m(2,1),m(2,2),m(2,3),
+        m(3,0),m(3,1),m(3,2),m(3,3)
+    );///joint transform
+    /*  osg::Matrixd  M (
+          m(0,0),m(1,0),m(2,0),m(3,0),
+          m(0,1),m(1,1),m(2,1) ,m(3,1),
+         m(0,2),m(1,2),m(2,2),m(3,2),
+           m(0,3),m(1,3),m(2,3),m(3,3)
+          );*/
+
+    M.postMult(_Mlocal);
+    setMatrix(M);
+}
+void Joint::setUrdfModel(const boost::shared_ptr<urdf::Joint >&l)
+{
+    _urdfmodel=l ;
+    _Mlocal.setTrans(osg::Vec3(
+                         (float)_urdfmodel->parent_to_joint_origin_transform.position.x,
+                         (float)_urdfmodel->parent_to_joint_origin_transform.position.y,
+                         (float)_urdfmodel->parent_to_joint_origin_transform.position.z
+                     ));
+    _Mlocal.setRotate(osg::Quat(
+                          (float)_urdfmodel->parent_to_joint_origin_transform.rotation.x,
+                          (float)_urdfmodel->parent_to_joint_origin_transform.rotation.y,
+                          (float)_urdfmodel->parent_to_joint_origin_transform.rotation.z,
+                          (float)_urdfmodel->parent_to_joint_origin_transform.rotation.w));
+}
 ///SE3Model.addBody (if DOF) + osg::Transform creation
 bool Robot::parse (boost::shared_ptr<urdf::Joint > &joint)
 {
@@ -250,7 +284,7 @@ bool Robot::parse (boost::shared_ptr<urdf::Joint > &joint)
 //SE3Model.addBody?
 
 ///set osg model
-    osg::Matrixf m;
+    osg::Matrixf m; ///local transform
     m.setTrans(osg::Vec3(
                    (float)joint->parent_to_joint_origin_transform.position.x,
                    (float)joint->parent_to_joint_origin_transform.position.y,

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -1,0 +1,137 @@
+#include "gepetto/viewer/robot.h"
+#include <osgDB/ReadFile>
+#include <osg/MatrixTransform>
+#include "pinocchio/multibody/model.hpp"
+using namespace graphics;
+
+Link *Robot::getOsgLink(boost::shared_ptr<urdf::Link >j)
+{
+    std::map< urdf::Link *,LinkIndex  >::iterator it= _invLinksMap.find(j.get());
+    return it!=_invLinksMap.end()? _osglinks[_invLinksMap[j.get()] ]:0;
+}
+Joint *Robot::getOsgJoint(boost::shared_ptr<urdf::Joint >j)
+{
+    std::map< urdf::Joint *,JointIndex  >::iterator it= _invJointsMap.find(j.get());
+    return it!=_invJointsMap.end()? _osgjoints[_invJointsMap[j.get()] ]:0;
+}
+//void getOsgJoint(JointIndex i){return }
+bool Robot::parse (boost::shared_ptr<urdf::Link > &link)
+{
+    osg::ref_ptr<Link> lastone=0,newone=0;
+    lastone=getOsgLink(link  );
+    if(!lastone.valid())newone=new Link();
+    else return true;//don't update previous ...newone=lastone;//update previous version
+    osg::ref_ptr<Joint> child=0,parent=0;
+    if(link->parent_joint)
+    {
+        parent=getOsgJoint(link->parent_joint);
+        if(!parent.valid())
+        {
+            //   std::cerr<<link->parent_joint->name<<"hasn't been added (Advice: add all joints before adding link)"<<std::endl;
+            if(!parse(link->parent_joint))        return false;
+            parent=getOsgJoint(link->parent_joint);
+        }
+    }
+    else std::cerr<<"link"<< link->name<<" havenojoint so it's the root"<<std::endl;
+
+
+
+///set State
+    newone->setName(link->name);
+    if(link->parent_joint)
+        parent->addChild(newone);
+    ///no parent join == root of skeleton?
+    else this->addChild(newone);
+
+    for(  std::vector<boost::shared_ptr<urdf::Joint> >::iterator it=link->child_joints.begin(); it!=link->child_joints.end(); it++)
+    {
+        child=getOsgJoint(*it);
+        if(!child)
+        {
+            parse(*it);
+            child=getOsgJoint(*it);
+        }
+        newone->addChild(child);
+
+    }
+
+
+
+    if(link->visual &&link->visual->geometry->type==urdf::Geometry::MESH)
+    {
+        boost::shared_ptr< ::urdf::Mesh > mesh_shared_ptr;
+
+
+        mesh_shared_ptr = boost::static_pointer_cast<  urdf::Mesh >
+                          ( link->visual->geometry );
+
+        if (mesh_shared_ptr->filename.substr(0, 10) != "package://")
+        {
+            throw std::runtime_error ("Error when parsing urdf file: "
+                                      "mesh filename should start with"
+                                      " \"package://\"");
+        }
+        std::string  mesh_path =  mesh_shared_ptr->filename.substr
+                                  (10, mesh_shared_ptr->filename.size());
+
+        osg::Node * node= osgDB::readNodeFile(_urdfPackageRootDirectory+mesh_path);//urdf::Geometry
+        if(!node)std::cerr<<_urdfPackageRootDirectory+mesh_path<<"botfound"<<std::endl;
+        else
+        {
+            osg::ref_ptr<osg::MatrixTransform > scaler=new osg::MatrixTransform();
+            scaler->setDataVariance(osg::Object::STATIC);
+            osg::Matrix m;
+            m.makeScale( mesh_shared_ptr->scale.x,mesh_shared_ptr->scale.x,mesh_shared_ptr->scale.x);
+            scaler->setMatrix(m);
+            scaler->addChild(node);
+            if(!_debugaxes )_debugaxes=osgDB::readNodeFile("axes.osgt");
+            scaler->addChild(_debugaxes);
+            newone->addChild(scaler);
+// osg_ref_ptr<Link> osgjoint=new
+            if(!lastone.valid())
+            {
+///actual add to model
+                _invLinksMap[link.get()]=_links.size();
+                _links.push_back(link);
+                _osglinks.push_back(newone);
+            }
+            return true;
+        }
+        return false;
+//osg::ref_ptr<node->asGroup()
+//if(node->asGroup)
+    }
+}
+///SE3Model.addBody (if DOF) + osg::Transform creation
+bool Robot::parse (boost::shared_ptr<urdf::Joint > &link)
+{
+    osg::ref_ptr<Joint> lastone=0,newone=0;
+    lastone=getOsgJoint(link  );
+    if(!lastone.valid())newone=new Joint();
+    else return true;//don't update previous ...newone=lastone;//update previous version
+
+
+///update state
+    newone->setPosition(osg::Vec3(
+                            (float)link->parent_to_joint_origin_transform.position.x,
+                            (float)link->parent_to_joint_origin_transform.position.y,
+                            (float)link->parent_to_joint_origin_transform.position.z
+                        ));
+    newone->setAttitude(osg::Quat(
+                            (float)link->parent_to_joint_origin_transform.rotation.x,
+                            (float)link->parent_to_joint_origin_transform.rotation.y,
+                            (float)link->parent_to_joint_origin_transform.rotation.z,
+                            (float)link->parent_to_joint_origin_transform.rotation.w
+                        ));
+
+
+    newone->setName(link->name);
+    if(!lastone.valid())
+    {
+///actual add to model
+        _invJointsMap[link.get()]=_joints.size();
+        _joints.push_back(link);
+        _osgjoints.push_back(newone);
+    }
+    return true;
+}

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -39,7 +39,7 @@ Robot* urdfParser::parse (const std::string& robotName,
         for (unsigned int i = 0 ; i < links.size() ; i++)
         {
             link_name = links[i]->name;
-            rob->parse(links[i]);
+            rob->addLink(links[i]);
 
         }
         return rob  ;

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -2,301 +2,46 @@
 //  urdf-parser.cpp
 //  gepetto-viewer
 //
-//  Created by Anthony Couret, Mathieu Geisert in November 2014.
+//  Created by J.Valentin in November 2014.
 //  Copyright (c) 2014 LAAS-CNRS. All rights reserved.
 //
-
 #include <gepetto/viewer/urdf-parser.h>
-#include <gepetto/viewer/leaf-node-cylinder.h>
-#include <gepetto/viewer/leaf-node-box.h>
-#include <gepetto/viewer/leaf-node-sphere.h>
+#include <urdf_parser/urdf_parser.h>
 
 namespace graphics {
 
-  namespace internal_urdf_parser
-  {
 
-    void getStaticTransform (const boost::shared_ptr < urdf::Link >& link,
-			     osgVector3 &static_pos, osgQuat &static_quat,
-			     bool visual)
+
+
+Robot* urdfParser::parse (const std::string& robotName,
+    const std::string& urdf_file_path,
+    const std::string& meshDataRootDir  )
     {
-      if (visual) {
-	// Set staticTransform = transform from link to visual
-	static_pos = osgVector3((float)link->visual->origin.position.x,
-				(float)link->visual->origin.position.y,
-				(float)link->visual->origin.position.z);
 
-	static_quat=osgQuat( (float)link->visual->origin.rotation.x,
-			     (float)link->visual->origin.rotation.y,
-			     (float)link->visual->origin.rotation.z,
-			     (float)link->visual->origin.rotation.w);
-      } else {
-	// Set staticTransform = transform from link to visual
-	static_pos = osgVector3((float)link->collision->origin.position.x,
-				(float)link->collision->origin.position.y,
-				(float)link->collision->origin.position.z);
 
-	static_quat=osgQuat( (float)link->collision->origin.rotation.x,
-			     (float)link->collision->origin.rotation.y,
-			     (float)link->collision->origin.rotation.z,
-			     (float)link->collision->origin.rotation.w);
-      }
-    }
-
-    void addMesh (const std::string &robotName,
-                  const std::string &meshDataRootDir,
-		  boost::shared_ptr < urdf::Link >& urdfLink,
-		  GroupNodePtr_t &robot, bool visual, bool linkFrame)
-    {
-      std::string link_name;
-      std::string mesh_path;
-      ::boost::shared_ptr< ::urdf::Mesh > mesh_shared_ptr;
-
-      if (visual) {
-	mesh_shared_ptr = boost::static_pointer_cast< ::urdf::Mesh >
-	  ( urdfLink->visual->geometry );
-      } else {
-	mesh_shared_ptr = boost::static_pointer_cast< ::urdf::Mesh >
-	  ( urdfLink->collision->geometry );
-      }
-      link_name = urdfLink->name;
-      std::cout << "Mesh " << std::endl;
-      if ( mesh_shared_ptr != 0 )
+        boost::shared_ptr< urdf::ModelInterface > model =
+        urdf::parseURDFFile( urdf_file_path );
+        // Test that file has correctly been parsed
+        if (!model)
         {
-	  if (mesh_shared_ptr->filename.substr(0, 10) != "package://") {
-	    throw std::runtime_error ("Error when parsing urdf file: "
-				      "mesh filename should start with"
-				      " \"package://\"");
-	  }
-          mesh_path =  mesh_shared_ptr->filename.substr
-	    (10, mesh_shared_ptr->filename.size());
-          LeafNodeColladaPtr_t link = LeafNodeCollada::create
-	    (robotName + "/" + link_name, meshDataRootDir + mesh_path);
-          osgVector3 static_pos; osgQuat static_quat;
-	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
-	  }
-          link->setStaticTransform(static_pos,static_quat);
-          link->setScale(osgVector3((float)mesh_shared_ptr->scale.x,
-                                    (float)mesh_shared_ptr->scale.y,
-                                    (float)mesh_shared_ptr->scale.z));
-
-          // Set Color if specified
-          if (visual && urdfLink->visual->material != NULL) {
-            osgVector4 color(urdfLink->visual->material->color.r, urdfLink->visual->material->color.g, urdfLink->visual->material->color.b, urdfLink->visual->material->color.a);
-            link->setColor(color);
-            if (urdfLink->visual->material->texture_filename != "") {
-              link->setTexture(urdfLink->visual->material->texture_filename);
-            }
-          }
-
-          // add links to robot node
-          robot->addChild(link);
+            throw std::runtime_error (std::string ("Failed to parse ") +
+            urdf_file_path);
         }
-    }
+        Robot*rob = new Robot();
+        rob->setUrdfPackageRootDirectory(meshDataRootDir);
+        std::vector< boost::shared_ptr < urdf::Link > > links;
+        //std::vector< boost::shared_ptr < urdf::Joint > > joints;
+        model->getLinks(links);
+        //model->getJoints(joints);
+        std::string link_name;
 
-    void addCylinder (const std::string &robotName,
-		      boost::shared_ptr < urdf::Link >& urdfLink,
-		      GroupNodePtr_t &robot, bool visual, bool linkFrame)
-    {
-      std::string link_name;
-      ::boost::shared_ptr< ::urdf::Cylinder > cylinder_shared_ptr;
 
-      if (visual) {
-	cylinder_shared_ptr = boost::static_pointer_cast < ::urdf::Cylinder >
-	  ( urdfLink->visual->geometry );
-      } else {
-	cylinder_shared_ptr = boost::static_pointer_cast < ::urdf::Cylinder >
-	  ( urdfLink->collision->geometry );
-      }
-      link_name = urdfLink->name;
-      std::cout << "Cylinder" << std::endl;
-      if ( cylinder_shared_ptr != 0 )
+        for (unsigned int i = 0 ; i < links.size() ; i++)
         {
-          LeafNodeCylinderPtr_t link = LeafNodeCylinder::create( robotName + "/" + link_name,
-                                                                 (float)cylinder_shared_ptr.get()->radius,
-                                                                 (float)cylinder_shared_ptr.get()->length);
-          osgVector3 static_pos; osgQuat static_quat;
-	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
-	  }
-          link->setStaticTransform(static_pos,static_quat);
+            link_name = links[i]->name;
+            rob->parse(links[i]);
 
-          // Set Color if specified
-          if (visual && urdfLink->visual->material != NULL) {
-            osgVector4 color(urdfLink->visual->material->color.r, urdfLink->visual->material->color.g, urdfLink->visual->material->color.b, urdfLink->visual->material->color.a);
-            link->setColor(color);
-            if (urdfLink->visual->material->texture_filename != "") {
-              link->setTexture(urdfLink->visual->material->texture_filename);
-            }
-          }
-
-          // add links to robot node
-          robot->addChild(link);
         }
+        return rob  ;
     }
-
-    void addBox (const std::string &robotName,
-		 boost::shared_ptr < urdf::Link >& urdfLink,
-		 GroupNodePtr_t &robot, bool visual, bool linkFrame)
-    {
-      std::string link_name;
-      ::boost::shared_ptr< ::urdf::Box > box_shared_ptr;
-
-      if (visual) {
-	box_shared_ptr = boost::static_pointer_cast< ::urdf::Box >
-	  ( urdfLink->visual->geometry);
-      } else {
-	box_shared_ptr = boost::static_pointer_cast< ::urdf::Box >
-	  ( urdfLink->collision->geometry);
-      }
-      link_name = urdfLink->name;
-      std::cout << "Box" << std::endl;
-      if ( box_shared_ptr != 0 ) {
-	LeafNodeBoxPtr_t link = LeafNodeBox::create
-	  (robotName + "/" + link_name,
-	   osgVector3((float)(.5*box_shared_ptr->dim.x),
-		      (float)(.5*box_shared_ptr->dim.y), 
-		      (float)(.5*box_shared_ptr->dim.z)));
-          osgVector3 static_pos; osgQuat static_quat;
-	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
-	  }
-          link->setStaticTransform(static_pos,static_quat);
-
-          // Set Color if specified
-          if (visual && urdfLink->visual->material != NULL) {
-            osgVector4 color(urdfLink->visual->material->color.r, urdfLink->visual->material->color.g, urdfLink->visual->material->color.b, urdfLink->visual->material->color.a);
-            link->setColor(color);
-            if (urdfLink->visual->material->texture_filename != "") {
-              link->setTexture(urdfLink->visual->material->texture_filename);
-            }
-          }
-          // add links to robot node
-          robot->addChild(link);
-        }
     }
-
-    void addSphere (const std::string &robotName,
-		    boost::shared_ptr < urdf::Link >& urdfLink,
-		    GroupNodePtr_t &robot, bool visual, bool linkFrame)
-    {
-      std::string link_name;
-      ::boost::shared_ptr< ::urdf::Sphere > sphere_shared_ptr;
-
-      if (visual) {
-	sphere_shared_ptr = boost::static_pointer_cast < ::urdf::Sphere >
-	  ( urdfLink->visual->geometry );
-      } else {
-	sphere_shared_ptr = boost::static_pointer_cast < ::urdf::Sphere >
-	  ( urdfLink->collision->geometry );
-      }
-      link_name = urdfLink->name;
-      std::cout << "Sphere" << std::endl;
-      if ( sphere_shared_ptr != 0 )
-        {
-          LeafNodeSpherePtr_t link = LeafNodeSphere::create( robotName + "/" + link_name,
-                                                             (float)sphere_shared_ptr.get()->radius);
-          osgVector3 static_pos; osgQuat static_quat;
-	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
-	  }
-          link->setStaticTransform(static_pos,static_quat);
-
-          // Set Color if specified
-          if (visual && urdfLink->visual->material != NULL) {
-            osgVector4 color(urdfLink->visual->material->color.r, urdfLink->visual->material->color.g, urdfLink->visual->material->color.b, urdfLink->visual->material->color.a);
-            link->setColor(color);
-            if (urdfLink->visual->material->texture_filename != "") {
-              link->setTexture(urdfLink->visual->material->texture_filename);
-            }
-          }
-
-          // add links to robot node
-          robot->addChild(link);
-        }
-    }
-
-  }
-
-  GroupNodePtr_t urdfParser::parse (const std::string& robotName,
-				    const std::string& urdf_file_path,
-				    const std::string& meshDataRootDir,
-				    const std::string& collisionOrVisual,
-				    const std::string& linkOrObjectFrame)
-  {
-    if (collisionOrVisual != "visual" && collisionOrVisual != "collision") {
-      throw std::runtime_error ("parameter collisionOrVisual should be either "
-				"\"collision\" or \"visual\"");
-    }
-    if (linkOrObjectFrame != "link" && linkOrObjectFrame != "object") {
-      throw std::runtime_error ("parameter linkOrObjectFrame should be either "
-				"\"link\" or \"object\"");
-    }
-    bool linkFrame = true;
-    if (linkOrObjectFrame == "object") linkFrame = false;
-
-    boost::shared_ptr< urdf::ModelInterface > model =
-      urdf::parseURDFFile( urdf_file_path );
-    // Test that file has correctly been parsed
-    if (!model) {
-      throw std::runtime_error (std::string ("Failed to parse ") +
-				urdf_file_path);
-    }
-    GroupNodePtr_t robot = GroupNode::create(robotName);
-    std::vector< boost::shared_ptr < urdf::Link > > links;
-    model->getLinks(links);
-    std::string link_name;
-
-    for (unsigned int i = 0 ; i < links.size() ; i++) {
-      link_name = links[i]->name;
-      std::cout << link_name << std::endl;
-
-      if (collisionOrVisual == "visual") {
-	if ( links[i]->visual != NULL && links[i]->visual->geometry != NULL) {
-	  switch (links[i]->visual->geometry->type) {
-	  case urdf::Geometry::MESH:
-	    internal_urdf_parser::addMesh (robotName, meshDataRootDir,
-					   links [i], robot, true, linkFrame);
-	    break;
-	  case urdf::Geometry::CYLINDER:
-	    internal_urdf_parser::addCylinder (robotName, links [i], robot,
-					       true, linkFrame);
-	    break;
-	  case urdf::Geometry::BOX:
-	    internal_urdf_parser::addBox (robotName, links [i], robot, true,
-					  linkFrame);
-	    break;
-	  case urdf::Geometry::SPHERE:
-	    internal_urdf_parser::addSphere (robotName, links [i], robot, true,
-					     linkFrame);
-	    break;
-	  }
-	}
-      } else {
-	if (links[i]->collision != NULL &&
-	    links[i]->collision->geometry != NULL) {
-	  switch (links[i]->collision->geometry->type) {
-	  case urdf::Geometry::MESH:
-	    internal_urdf_parser::addMesh (robotName, meshDataRootDir,
-					   links [i], robot, false, linkFrame);
-	    break;
-	  case urdf::Geometry::CYLINDER:
-	    internal_urdf_parser::addCylinder (robotName, links [i], robot,
-					      false, linkFrame);
-	    break;
-	  case urdf::Geometry::BOX:
-	    internal_urdf_parser::addBox (robotName, links [i], robot, false,
-					  linkFrame);
-	    break;
-	  case urdf::Geometry::SPHERE:
-	    internal_urdf_parser::addSphere (robotName, links [i], robot, false,
-					    linkFrame);
-	    break;
-	  }
-	}
-      }
-    }
-    return robot;
-  }
-}

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -7,6 +7,7 @@
 //
 #include <gepetto/viewer/urdf-parser.h>
 #include <urdf_parser/urdf_parser.h>
+#include <osgDB/WriteFile>
 
 namespace graphics {
 
@@ -42,6 +43,9 @@ Robot* urdfParser::parse (const std::string& robotName,
             rob->addLink(links[i]);
 
         }
+        osg::Group*gr=new osg::Group();
+
+        osgDB::writeNodeFile(*rob,"readrobot.osg");
         return rob  ;
     }
     }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -25,69 +25,13 @@
 
   {
     using namespace graphics;
+osg::ref_ptr< graphics::Robot > modelNode=    graphics:: urdfParser::parse(std::string("hrp2"),
+    std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf"),
+    std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/"));
 
-    LeafNodeBoxPtr_t box = LeafNodeBox::create("box1", osgVector3(1.,1.,1.));
-    /*LeafNodeCapsulePtr_t capsule = LeafNodeCapsule::create("capsule1", 1,1);
-    LeafNodeConePtr_t cone = LeafNodeCone::create("cone", 1,1);
-    LeafNodeCylinderPtr_t cylindre = LeafNodeCylinder::create("cylindre", 1,1);
-    LeafNodeSpherePtr_t sphere = LeafNodeSphere::create("sphere", 1);
-    LeafNodeGroundPtr_t ground = LeafNodeGround::create("ground");*/
-    //LeafNodeColladaPtr_t collada = LeafNodeCollada::create("collada","/home/simeval/AluminumChair.dae");
-    box->addLandmark(1.);
-    //LeafNodeLinePtr_t line = LeafNodeLine::create(std::string("line"), osgVector3(1.0,1.0,1.0), osgVector3(0.0,0.0,0.0));
-    //LeafNodeFacePtr_t face = LeafNodeFace::create(std::string("face"), osgVector3(0.0,0.0,0.0), osgVector3(-2.0,0.0,0.0), osgVector3(-2.0,-2.0,0.0), osgVector3(0.0,-2.0,0.0));
-    //face->addVertex(osgVector3(0.,0.,2.));
-
-    GroupNodePtr_t world = GroupNode::create(std::string("world"));
-    //GroupNodePtr_t robot = GroupNode::create(std::string("robot"));
-    //GroupNodePtr_t robot = urdfParser::parse(std::string("hrp2"), std::string("/local/mgeisert/devel/src/hrp2/hrp2_14_description/urdf/hrp2_14_capsule.urdf"),std::string("/local/mgeisert/devel/src/hrp2/"));
-
-
-    /*world->addChild(robot);
-    world->addChild(obstacle);
-
-    DefVector3 position1(2.,0.,0.);
-    DefQuat attitude1(1.,0.,0.,0.);
-    Tools::ConfigurationPtr_t config1 = Tools::Configuration::create(position1, attitude1);
-    DefVector3 position2(0.,2.,0.);
-    DefQuat attitude2(1.,0.,0.,0.);
-    Tools::ConfigurationPtr_t config2 = Tools::Configuration::create(position2, attitude2);
-
-    robot->addChild(box);
-    robot->applyConfiguration(config1);
-    box->applyConfiguration(config1);
-    robot->addChild(capsule);
-    capsule->setVisibilityMode(VISIBILITY_OFF);
-    robot->addChild(cone);
-    cone->applyConfiguration(config2);
-    cone->setColor(osgVector4(1.,1.,0.5,1.));
-    cone->setVisibilityMode(VISIBILITY_ON);
-    DefVector3 position3(0.,0.,8.);
-    DefQuat attitude3(1.,0.,0.,0.);
-    Tools::ConfigurationPtr_t config3 = Tools::Configuration::create(position3, attitude3);
-    obstacle->applyConfiguration(config3);
-    obstacle->addChild(cylindre);
-    sphere->applyConfiguration(config2);
-    obstacle->addChild(sphere);
-    sphere->setAlpha(0.1f);
-    world->addChild(ground);
-    world->addChild(collada);
-    collada->applyConfiguration(config2);
-    std::string name("world/robot/genou");
-    std::cout << (parseName(name)) << std::endl;*/
-
-    //world->addChild(ground);
-    //world->addChild(line);
-    world->addChild(box);
-    //world->addChild(robot);
-    WindowManagerPtr_t gm = WindowManager::create();
-    gm->addNode(world);
-    //osgViewer::Viewer viewer;
-    //viewer.setSceneData( world->asGroup() );
-    box->deleteLandmark();
-    box->addLandmark(2.);
-    box->applyConfiguration(osgVector3(0.,0.,0.), osgQuat(0.884,0.306,-0.177,0.306));
-    world->addLandmark(1.);
-
-    return gm->run();
+  osgViewer::Viewer viewer;
+    viewer.setUpViewInWindow( 10, 30, 800, 600 );
+    viewer.setSceneData( modelNode );
+  viewer.realize();
+  viewer.run();
   }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -21,6 +21,48 @@
 #include <gepetto/viewer/leaf-node-collada.h>
 #include <gepetto/viewer/urdf-parser.h>
 
+#include <osgViewer/ViewerEventHandlers>
+
+#include <osgGA/TrackballManipulator>
+#include <osgGA/FlightManipulator>
+#include <osgGA/DriveManipulator>
+#include <osgGA/KeySwitchMatrixManipulator>
+#include <osgGA/StateSetManipulator>
+#include <osgGA/AnimationPathManipulator>
+#include <osgGA/TerrainManipulator>
+#include <osgGA/SphericalManipulator>
+
+
+class myKeyboardEventHandler : public osgGA::GUIEventHandler
+    {
+    public:
+   graphics:: RobotUpdate *_control;
+    myKeyboardEventHandler(graphics::RobotUpdate *controller):_control(controller){}
+       virtual bool handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter&);
+       virtual void accept(osgGA::GUIEventHandlerVisitor& v)   { v.visit(*this); };
+    };
+
+    bool myKeyboardEventHandler::handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter& aa)
+     {
+       switch(ea.getEventType())
+       {
+       case(osgGA::GUIEventAdapter::KEYDOWN):
+          {
+             switch(ea.getKey())
+             {
+             case 'w':
+                std::cout << " w key pressed" << std::endl;
+            _control->addOrder(new graphics::SwitchDebugOrder(*_control->getRobot()));
+                return false;
+                break;
+             default:
+                return false;
+             }
+          }
+       default:
+          return false;
+       }
+    }
   int main(int, const char**)
 
   {
@@ -28,8 +70,31 @@
 osg::ref_ptr< graphics::Robot > modelNode=    graphics:: urdfParser::parse(std::string("hrp2"),
     std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf"),
     std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/"));
+  osg::ref_ptr< RobotUpdate > controller= new RobotUpdate(modelNode);
+modelNode->addUpdateCallback(controller);
 
   osgViewer::Viewer viewer;
+  viewer.addEventHandler(new myKeyboardEventHandler(controller));
+    // add the thread model handler
+    viewer.addEventHandler(new osgViewer::ThreadingHandler);
+
+    // add the window size toggle handler
+    viewer.addEventHandler(new osgViewer::WindowSizeHandler);
+
+    // add the stats handler
+    viewer.addEventHandler(new osgViewer::StatsHandler);
+
+    // add the help handler
+    //viewer.addEventHandler(new osgViewer::HelpHandler(arguments.getApplicationUsage()));
+
+    // add the record camera path handler
+    viewer.addEventHandler(new osgViewer::RecordCameraPathHandler);
+
+    // add the LOD Scale handler
+    viewer.addEventHandler(new osgViewer::LODScaleHandler);
+
+    // add the screen capture handler
+    viewer.addEventHandler(new osgViewer::ScreenCaptureHandler);
     viewer.setUpViewInWindow( 10, 30, 800, 600 );
     viewer.setSceneData( modelNode );
   viewer.realize();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -34,47 +34,50 @@
 
 
 class myKeyboardEventHandler : public osgGA::GUIEventHandler
+{
+public:
+    graphics:: RobotUpdate *_control;
+    myKeyboardEventHandler(graphics::RobotUpdate *controller):_control(controller) {}
+    virtual bool handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter&);
+    virtual void accept(osgGA::GUIEventHandlerVisitor& v)
     {
-    public:
-   graphics:: RobotUpdate *_control;
-    myKeyboardEventHandler(graphics::RobotUpdate *controller):_control(controller){}
-       virtual bool handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter&);
-       virtual void accept(osgGA::GUIEventHandlerVisitor& v)   { v.visit(*this); };
+        v.visit(*this);
     };
+};
 
-    bool myKeyboardEventHandler::handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter& aa)
-     {
-       switch(ea.getEventType())
-       {
-       case(osgGA::GUIEventAdapter::KEYDOWN):
-          {
-             switch(ea.getKey())
-             {
-             case 'w':
-                std::cout << " w key pressed" << std::endl;
+bool myKeyboardEventHandler::handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIActionAdapter& aa)
+{
+    switch(ea.getEventType())
+    {
+    case(osgGA::GUIEventAdapter::KEYDOWN):
+    {
+        switch(ea.getKey())
+        {
+        case 'w':
+            std::cout << " w key pressed" << std::endl;
             _control->addOrder(new graphics::SwitchDebugOrder(*_control->getRobot()));
-                return false;
-                break;
-             default:
-                return false;
-             }
-          }
-       default:
-          return false;
-       }
+            return false;
+            break;
+        default:
+            return false;
+        }
     }
-  int main(int, const char**)
+    default:
+        return false;
+    }
+}
+int main(int, const char**)
 
-  {
+{
     using namespace graphics;
-osg::ref_ptr< graphics::Robot > modelNode=    graphics:: urdfParser::parse(std::string("hrp2"),
-    std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf"),
-    std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/"));
-  osg::ref_ptr< RobotUpdate > controller= new RobotUpdate(modelNode);
-modelNode->addUpdateCallback(controller);
+    osg::ref_ptr< graphics::Robot > modelNode=    graphics:: urdfParser::parse(std::string("hrp2"),
+            std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf"),
+            std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/"));
+    osg::ref_ptr< RobotUpdate > controller= new RobotUpdate(modelNode);
+    modelNode->addUpdateCallback(controller);
 
-  osgViewer::Viewer viewer;
-  viewer.addEventHandler(new myKeyboardEventHandler(controller));
+    osgViewer::Viewer viewer;
+    viewer.addEventHandler(new myKeyboardEventHandler(controller));
     // add the thread model handler
     viewer.addEventHandler(new osgViewer::ThreadingHandler);
 
@@ -97,6 +100,6 @@ modelNode->addUpdateCallback(controller);
     viewer.addEventHandler(new osgViewer::ScreenCaptureHandler);
     viewer.setUpViewInWindow( 10, 30, 800, 600 );
     viewer.setSceneData( modelNode );
-  viewer.realize();
-  viewer.run();
-  }
+    viewer.realize();
+    viewer.run();
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -7,7 +7,7 @@
 //
 
 #include <iostream>
-#include <gepetto/viewer/window-manager.h>
+#include <gepetto/viewer/viewer.h>
 #include <gepetto/viewer/node.h>
 #include <gepetto/viewer/group-node.h>
 #include <gepetto/viewer/leaf-node-box.h>
@@ -66,10 +66,13 @@ bool myKeyboardEventHandler::handle(const osgGA::GUIEventAdapter& ea,osgGA::GUIA
         return false;
     }
 }
+
 int main(int, const char**)
 
 {
     using namespace graphics;
+    RobotViewer threaded;
+    threaded.start();
     osg::ref_ptr< graphics::Robot > modelNode=    graphics:: urdfParser::parse(std::string("hrp2"),
             std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf"),
             std::string("/home/xeul/SRC/Pinocchio/nao_robot-master/"));

--- a/tests/test.py
+++ b/tests/test.py
@@ -13,12 +13,11 @@ rob.setUrdfFile("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/
 
 rob.setDebugCollisionOnOff()
 rob.setDebugCollisionOnOff()
-#problem to get synchronisly the joint while previous steps not finished
-time.sleep(1)
-#jointid=-1 if model not finished loading
+ 
 jointid=rob.getVisuJointID("LFinger12")
 
 q=se3.SE3()
 q.rotation=se3.utils.rpyToMatrix([1,0,0])
 
 rob.setConfiguration(jointid,q)
+

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,8 +3,8 @@ import pinocchio.utils
 import gepetto 
 import time
 
-import numpy as np
-import matrix as eigenpy
+#import numpy as np
+#import matrix as eigenpy
 viewer=gepetto.RobotViewer()
 viewer.start()
 rob=viewer.addNewRobot()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,17 @@
+import pinocchio as se3
+import pinocchio.utils
+import gepetto 
+
+import numpy as np
+import matrix as eigenpy
+viewer=gepetto.RobotViewer()
+viewer.start()
+rob=viewer.addNewRobot()
+rob.setUrdfPackageDirectory("/home/xeul/SRC/Pinocchio/nao_robot-master/")
+rob.setUrdfFile("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/naoV50_generated_urdf/nao.urdf")
+
+rob.setDebugCollisionOnOff()
+rob.setDebugCollisionOnOff()
+jointid=rob.getVisuJointID("base_link_fixedjoint")
+q=se3.SE3()
+rob.setConfiguration(jointid,q)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,7 @@
 import pinocchio as se3
 import pinocchio.utils
 import gepetto 
+import time
 
 import numpy as np
 import matrix as eigenpy
@@ -12,6 +13,12 @@ rob.setUrdfFile("/home/xeul/SRC/Pinocchio/nao_robot-master/nao_description/urdf/
 
 rob.setDebugCollisionOnOff()
 rob.setDebugCollisionOnOff()
-jointid=rob.getVisuJointID("base_link_fixedjoint")
+#problem to get synchronisly the joint while previous steps not finished
+time.sleep(1)
+#jointid=-1 if model not finished loading
+jointid=rob.getVisuJointID("LFinger12")
+
 q=se3.SE3()
+q.rotation=se3.utils.rpyToMatrix([1,0,0])
+
 rob.setConfiguration(jointid,q)


### PR DESCRIPTION


I didn't understand the underlying model..Is there any hard constraint to interface gepetto with sot and ros? ...
I saw in pinocchio tutorial that the viewer is created via corba but don't understand the "why" of the current twisted design..(neither the use of corba in this context):/
Further the parser seamed not to parse joints so i rewrites all and simplified it a lot...

So this version of the viewer:
can be used as standalone application or used via python wrapper (see test.py)...not via corba
support all Threading Model of osg
can control robot from other thread throught RobotUpdate "remote controller".

TODO:
-define a (minimal) corba Interface in gepetto-viewer-corba
-populate attached SE3Model and add dirtyflag and sync with SE3Model method
-add more features (addView, addNode, setAnimationPath...)

I have also began to make urdf a Bullet ragdoll using osgBullet, ask me if you interested in it
