### PR TITLE
Fix path concatenation and set vsync to true

### DIFF
--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -71,7 +71,7 @@ namespace graphics {
           mesh_path =  mesh_shared_ptr->filename.substr
 	    (10, mesh_shared_ptr->filename.size());
           LeafNodeColladaPtr_t link = LeafNodeCollada::create
-	    (robotName + "/" + link_name, meshDataRootDir + mesh_path);
+	    (robotName + "/" + link_name, meshDataRootDir + "/" + mesh_path);
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
 	    getStaticTransform (urdfLink, static_pos, static_quat, visual);

--- a/src/window-manager.cpp
+++ b/src/window-manager.cpp
@@ -32,6 +32,7 @@ namespace graphics {
       traits_ptr->sharedContext = 0;
       traits_ptr->sampleBuffers = 1;
       traits_ptr->samples = 1;
+      traits_ptr->vsync = true;
       traits_ptr->readDISPLAY ();
       traits_ptr->setUndefinedScreenDetailsToDefaultScreen ();
 


### PR DESCRIPTION
Fix concatenation of the argument "meshDataRootDir" of the URDF parser and object description files.

Setting vsync to true helps to decrease CPU usage of the viewer.