### PR TITLE
correct bug when loading a urdf with .obj meshs (rotation around x axis)

### DIFF
--- a/src/leaf-node-collada.cpp
+++ b/src/leaf-node-collada.cpp
@@ -16,7 +16,14 @@ namespace graphics {
 
   void LeafNodeCollada::init()
   {
-    collada_ptr_ = osgDB::readNodeFile(collada_file_path_);
+    // get the extension of the meshs file
+    std::string ext = collada_file_path_.substr(collada_file_path_.find_last_of(".")+1,collada_file_path_.size());
+    if(ext == "obj"){
+      const osgDB::Options* options = new osgDB::Options("noRotation");
+      collada_ptr_ = osgDB::readNodeFile(collada_file_path_,options);
+      }
+    else
+      collada_ptr_ = osgDB::readNodeFile(collada_file_path_);
         
     /* Create PositionAttitudeTransform */
     this->asQueue()->addChild(collada_ptr_);


### PR DESCRIPTION
When you load a urdf file for an environment with meshs, the \<visual\> meshs are parsed by osgDB  parser in gepetto-viewer and the \<collision\> meshs are parsed by ASSIMP in hpp-model-urdf. For some format (ie : .obj) the parsers don't use the same conventions.

I add a specific option for .obj files in order to use the same convention. Maybe the option is needed for other formats ... (.dae and .stl are OK)