### PR TITLE
[urdf-parser] Fix issues with displaying multiple visual

### DIFF
--- a/src/leaf-node-collada.cpp
+++ b/src/leaf-node-collada.cpp
@@ -29,8 +29,11 @@ namespace graphics {
     this->asQueue()->addChild(collada_ptr_);
         
     /* Allow transparency */
-    collada_ptr_->getOrCreateStateSet()->setRenderBinDetails(10, "DepthSortedBin");
-    collada_ptr_->getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+    if (collada_ptr_->getOrCreateStateSet())
+      {
+	collada_ptr_->getOrCreateStateSet()->setRenderBinDetails(10, "DepthSortedBin");
+	collada_ptr_->getOrCreateStateSet()->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+      }
   }
     
   LeafNodeCollada::LeafNodeCollada(const std::string& name, const std::string& collada_file_path) :
@@ -128,7 +131,8 @@ namespace graphics {
     //setColor(collada_ptr_,color);
     osg::ref_ptr<osg::Material> mat_ptr (new osg::Material); 
     mat_ptr->setDiffuse(osg::Material::FRONT_AND_BACK,color); 
-    collada_ptr_->getStateSet()->setAttribute(mat_ptr.get());    
+    if (collada_ptr_->getStateSet())
+      collada_ptr_->getStateSet()->setAttribute(mat_ptr.get());    
   }
  
   void LeafNodeCollada::setTexture(const std::string& image_path)

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -26,18 +26,34 @@ namespace graphics {
 
     void getStaticTransform (const boost::shared_ptr < urdf::Link >& link,
 			     osgVector3 &static_pos, osgQuat &static_quat,
-			     bool visual)
+			     bool visual, long unsigned int visual_index)
     {
-      if (visual) {
-	// Set staticTransform = transform from link to visual
-	static_pos = osgVector3((float)link->visual->origin.position.x,
-				(float)link->visual->origin.position.y,
-				(float)link->visual->origin.position.z);
-
-	static_quat=osgQuat( (float)link->visual->origin.rotation.x,
-			     (float)link->visual->origin.rotation.y,
-			     (float)link->visual->origin.rotation.z,
-			     (float)link->visual->origin.rotation.w);
+      if (visual || (link->visual_array.size()>1))
+	{
+	  if (link->visual_array.size()>1)
+	    {
+	      // Set staticTransform = transform from link to visual
+	      static_pos = osgVector3((float)link->visual_array[visual_index]->origin.position.x,
+				      (float)link->visual_array[visual_index]->origin.position.y,
+				      (float)link->visual_array[visual_index]->origin.position.z);
+	      
+	      static_quat=osgQuat( (float)link->visual_array[visual_index]->origin.rotation.x,
+				   (float)link->visual_array[visual_index]->origin.rotation.y,
+				   (float)link->visual_array[visual_index]->origin.rotation.z,
+				   (float)link->visual_array[visual_index]->origin.rotation.w);
+	    }
+	  else
+	    {
+	      // Set staticTransform = transform from link to visual
+	      static_pos = osgVector3((float)link->visual->origin.position.x,
+				      (float)link->visual->origin.position.y,
+				      (float)link->visual->origin.position.z);
+	      
+	      static_quat=osgQuat( (float)link->visual->origin.rotation.x,
+				   (float)link->visual->origin.rotation.y,
+				   (float)link->visual->origin.rotation.z,
+				   (float)link->visual->origin.rotation.w);
+	    }
       } else {
 	// Set staticTransform = transform from link to visual
 	static_pos = osgVector3((float)link->collision->origin.position.x,
@@ -69,7 +85,6 @@ namespace graphics {
 	  ( urdfLink->collision_array [j]->geometry );
       }
       link_name = urdfLink->name;
-      std::cout << "Mesh " << std::endl;
       if ( mesh_shared_ptr != 0 )
         {
           mesh_path = getFilename (mesh_shared_ptr->filename, meshDataRootDir);
@@ -79,7 +94,7 @@ namespace graphics {
 	    (oss.str (), mesh_path);
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
+	    getStaticTransform (urdfLink, static_pos, static_quat, visual,j);
 	  }
           meshNode->setStaticTransform(static_pos,static_quat);
           meshNode->setScale(osgVector3((float)mesh_shared_ptr->scale.x,
@@ -89,7 +104,10 @@ namespace graphics {
 	  linkNode->addChild (meshNode);
           // Set Color if specified
           if (visual && urdfLink->visual_array [j]->material != NULL) {
-            osgVector4 color(urdfLink->visual_array [j]->material->color.r, urdfLink->visual_array [j]->material->color.g, urdfLink->visual_array [j]->material->color.b, urdfLink->visual_array [j]->material->color.a);
+            osgVector4 color(urdfLink->visual_array [j]->material->color.r, 
+			     urdfLink->visual_array [j]->material->color.g, 
+			     urdfLink->visual_array [j]->material->color.b, 
+			     urdfLink->visual_array [j]->material->color.a);
             meshNode->setColor(color);
             if (urdfLink->visual_array [j]->material->texture_filename != "") {
               std::string textureFilename = getFilename
@@ -128,7 +146,7 @@ namespace graphics {
 	      (float)cylinder_shared_ptr.get()->length));
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
+	    getStaticTransform (urdfLink, static_pos, static_quat, visual,j);
 	  }
           cylinderNode->setStaticTransform(static_pos,static_quat);
 
@@ -176,7 +194,7 @@ namespace graphics {
 		      (float)(.5*box_shared_ptr->dim.z)));
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
+	    getStaticTransform (urdfLink, static_pos, static_quat, visual,j);
 	  }
           boxNode->setStaticTransform(static_pos,static_quat);
 
@@ -222,7 +240,7 @@ namespace graphics {
 				    (float)sphere_shared_ptr.get()->radius));
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {
-	    getStaticTransform (urdfLink, static_pos, static_quat, visual);
+	    getStaticTransform (urdfLink, static_pos, static_quat, visual,j);
 	  }
           sphereNode->setStaticTransform(static_pos,static_quat);
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -40,11 +40,13 @@
 
     GroupNodePtr_t world = GroupNode::create(std::string("world"));
     //GroupNodePtr_t robot = GroupNode::create(std::string("robot"));
-    //GroupNodePtr_t robot = urdfParser::parse(std::string("hrp2"), std::string("/local/mgeisert/devel/src/hrp2/hrp2_14_description/urdf/hrp2_14_capsule.urdf"),std::string("/local/mgeisert/devel/src/hrp2/"));
+    //    GroupNodePtr_t robot = urdfParser::parse(std::string("hrp2"), 
+    //std::string("/home/ostasse/devel/ros-indigo-1/install/share/hrp2_14_description/urdf/hrp2_14.urdf"),
+    //std::string("/home/ostasse/devel/ros-indigo-1/install/share/"));
 
 
-    /*world->addChild(robot);
-    world->addChild(obstacle);
+    world->addChild(box);
+    /*world->addChild(obstacle);
 
     DefVector3 position1(2.,0.,0.);
     DefQuat attitude1(1.,0.,0.,0.);


### PR DESCRIPTION
This pull-request fixes a problem in displaying multiple visual in urdf files. The Tiago robot
(https://github.com/pal-robotics/tiago_robot) for instance is using multiple visual (arm_3_link). The problem is due to the getStaticTransform which considers only the field visual in the urdfLink structure. Setting the correct element of the visual_array fixes the problem (see /usr/include/urdf_model/link.h).

Incidentally, this pull request adds also test on attributes which are failing when loading STL files. 