### PR TITLE
Add leaf-node-mesh to handle meshes build without loading a file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(${PROJECT_NAME}_HEADERS
   include/gepetto/viewer/leaf-node-face.h
   include/gepetto/viewer/leaf-node-ground.h
   include/gepetto/viewer/leaf-node-line.h
+  include/gepetto/viewer/leaf-node-mesh.h
   include/gepetto/viewer/leaf-node-sphere.h
   include/gepetto/viewer/leaf-node-light.h
   include/gepetto/viewer/leaf-node-arrow.h

--- a/include/gepetto/viewer/leaf-node-mesh.h
+++ b/include/gepetto/viewer/leaf-node-mesh.h
@@ -1,0 +1,99 @@
+//
+//  leaf-node-mesh.h
+//  gepetto-viewer
+//
+//  Created by Olivier Stasse, Justin Carpentier, Anthony Couret, Mathieu Geisert in November 2014.
+//  Copyright (c) 2016 LAAS-CNRS. All rights reserved.
+//
+
+#ifndef SCENEVIEWER_LEAFNODEMESH_HH
+#define SCENEVIEWER_LEAFNODEMESH_HH
+
+#include <gepetto/viewer/node.h>
+#include <osg/PrimitiveSet>
+#include <osg/Geometry>
+
+namespace graphics {
+    DEF_CLASS_SMART_PTR(LeafNodeMesh)
+    
+    /** Implementation of the Mesh GraphicalObject in OSG render */
+    class LeafNodeMesh : public Node
+    {
+    private:
+
+        /** Associated weak pointer */
+        LeafNodeMeshWeakPtr weak_ptr_;
+        
+        /** Associated mesh geometry */
+	osg::Geometry*  mesh_geometry_ptr_;
+
+        /** Associated ShapeDrawable */
+        ::osg::ShapeDrawableRefPtr shape_drawable_ptr_;
+        
+        void init();
+        
+        /* Default constructor */
+        LeafNodeMesh(const std::string &name);
+        /* Copy constructor */
+        LeafNodeMesh(const LeafNodeMesh& other);
+        LeafNodeMesh(const std::string &name,const osgVector4 & color);
+        
+        /** Initialize weak_ptr */
+        void initWeakPtr (LeafNodeMeshWeakPtr other_weak_ptr);
+
+        
+    protected:
+    public:
+        /** Static method which create a new LeafNodeCollada
+         */
+        static LeafNodeMeshPtr_t create(const std:: string &name);
+    static LeafNodeMeshPtr_t create(const std::string &name, const osgVector4& color);
+        
+        /** Static method for creating a clone of LeafNodeMesh other
+         */
+        static LeafNodeMeshPtr_t createCopy(LeafNodeMeshPtr_t other);
+        
+        /** Proceed to a clonage of the current object defined by the copy constructor
+         */
+        virtual LeafNodeMeshPtr_t clone(void) const;
+        
+
+        /** Copy
+         \brief Proceed to a copy of the currend object as clone
+         */
+        virtual LeafNodeMeshPtr_t copy() const { return clone(); }
+        
+        /** Return a shared pointer of the current object
+         */
+        LeafNodeMeshPtr_t self(void) const;
+        
+        void setColor(const osgVector4& color);   
+
+        void setTexture(const std::string& image_path);     
+
+	virtual void setAlpha(const float& alpha);
+	virtual osg::ref_ptr<osg::Node> getOsgNode() const;
+
+        SCENE_VIEWER_ACCEPT_VISITOR;
+
+	/** Add geometric data */
+	/** Set the vertices of the mesh */
+	void setVertexArray(osg::Vec3ArrayRefPtr arrayOfVertices);
+	
+	/** Add a primitive set to the mesh */
+	void addPrimitiveSet(osg::DrawElementsUInt * aSetOfColors);
+	
+        void setColorBinding(osg::Geometry::AttributeBinding aColorBinding);
+	/** Add colors */
+	void setColorArray(osg::Vec4ArrayRefPtr colors);
+
+        /** Add normals */
+        void setNormalArray(osg::Vec3ArrayRefPtr normals);
+        void setNormalBinding(osg::Geometry::AttributeBinding aNormalBinding);
+        /** Destructor */
+        virtual ~LeafNodeMesh();
+        
+    };
+} /* namespace graphics */
+
+#endif /* SCENEVIEWER_LEAFNODECOLLADA_HH */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(${LIBRARY_NAME}_SOURCES
   leaf-node-ground.cpp
   leaf-node-collada.cpp
   leaf-node-light.cpp
+  leaf-node-mesh.cpp
   urdf-parser.cpp
   leaf-node-xyzaxis.cpp
   leaf-node-arrow.cpp

--- a/src/leaf-node-mesh.cpp
+++ b/src/leaf-node-mesh.cpp
@@ -1,0 +1,217 @@
+//
+//  leaf-node-mesh.cpp
+//  gepetto-viewer
+//
+//  Created by Olivier Stasse, Anthony Couret, Mathieu Geisert.
+//  Copyright (c) 2016 LAAS-CNRS. All rights reserved.
+//
+
+#include <sys/stat.h>
+#include <fstream>
+#include <ios>
+#include <gepetto/viewer/leaf-node-mesh.h>
+#include <osgDB/ReadFile>
+
+namespace graphics {
+    
+  /* Declaration of private function members */
+
+  void LeafNodeMesh::init()
+  {
+    
+    /* Create Geode for adding ShapeDrawable */
+    geode_ptr_ = new osg::Geode ();
+
+    /* Create mesh geometry */
+    mesh_geometry_ptr_ = new osg::Geometry();
+    geode_ptr_->addDrawable(mesh_geometry_ptr_);
+    
+    /* Create PositionAttitudeTransform */
+    this->asQueue()->addChild(geode_ptr_);
+        
+    /* Allow transparency */
+    if (mesh_geometry_ptr_->getOrCreateStateSet())
+      {
+	osg::ref_ptr<osg::StateSet> nodess (mesh_geometry_ptr_->getOrCreateStateSet());
+	nodess->setMode(GL_BLEND, ::osg::StateAttribute::ON);
+	// Create Material and assign color.
+
+	// Creating the material object
+	osg::ref_ptr<osg::Material> mat (new osg::Material);
+
+	//Attaching the newly defined state set object to the node state set
+	//mat->setColorMode(osg::Material::AMBIENT_AND_DIFFUSE);
+	mat->setColorMode(osg::Material::SPECULAR);
+	nodess->setAttribute(mat.get());
+
+      }
+  }
+    
+  LeafNodeMesh::LeafNodeMesh(const std::string & name) :
+    Node(name)
+  {
+    init();
+  }
+    
+  LeafNodeMesh::LeafNodeMesh(const std::string &name, const osgVector4& color) :
+    Node(name)
+  {
+    init();
+    setColor(color);
+  }
+  
+  LeafNodeMesh::LeafNodeMesh(const graphics::LeafNodeMesh& other) :
+    Node(other.getID())
+  {
+    init();
+  }
+    
+
+  void LeafNodeMesh::initWeakPtr(LeafNodeMeshWeakPtr other_weak_ptr)
+  {
+    weak_ptr_ = other_weak_ptr;
+  }
+    
+  /* End of declaration of private function members */
+    
+  /* Declaration of protected function members */
+    
+  LeafNodeMeshPtr_t LeafNodeMesh::create(const std::string& name)
+  {
+    LeafNodeMeshPtr_t shared_ptr(new LeafNodeMesh
+                                    (name));
+    
+    // Add reference to itself
+    shared_ptr->initWeakPtr(shared_ptr);
+    
+    return shared_ptr;
+  }
+
+  LeafNodeMeshPtr_t LeafNodeMesh::create(const std::string& name, const osgVector4& color)
+  {
+    LeafNodeMeshPtr_t shared_ptr(new LeafNodeMesh
+                                    (name, color));
+    
+    // Add reference to itself
+    shared_ptr->initWeakPtr(shared_ptr);
+    
+    return shared_ptr;
+  }
+    
+  LeafNodeMeshPtr_t LeafNodeMesh::createCopy(LeafNodeMeshPtr_t other)
+  {
+    LeafNodeMeshPtr_t shared_ptr(new LeafNodeMesh(*other));
+        
+    // Add reference to itself
+    shared_ptr->initWeakPtr(shared_ptr);
+        
+    return shared_ptr;
+  }
+
+
+  /* End of declaration of protected function members */
+    
+  /* Declaration of public function members */
+    
+  LeafNodeMeshPtr_t LeafNodeMesh::clone(void) const
+  {
+    return LeafNodeMesh::createCopy(weak_ptr_.lock());
+  }
+    
+  LeafNodeMeshPtr_t LeafNodeMesh::self(void) const
+  {
+    return weak_ptr_.lock();
+  }
+    
+  void LeafNodeMesh::setColor(const osgVector4& color)
+  {
+    //setColor(collada_ptr_,color);
+    osg::ref_ptr<osg::Material> mat_ptr (new osg::Material); 
+    mat_ptr->setDiffuse(osg::Material::FRONT_AND_BACK,color); 
+    if (mesh_geometry_ptr_->getStateSet())
+      mesh_geometry_ptr_->getStateSet()->setAttribute(mat_ptr.get());    
+  }
+
+  void LeafNodeMesh::setAlpha(const float& alpha)
+  {
+    osg::StateSet* ss = mesh_geometry_ptr_->getStateSet();
+    if (ss)
+      {
+	alpha_ = alpha;
+	osg::Material *mat;
+	if (ss->getAttribute(osg::StateAttribute::MATERIAL))
+	  mat = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
+	else
+	  {
+	    mat = new osg::Material;
+	    ss->setAttribute(mat, osg::StateAttribute::OFF | osg::StateAttribute::OVERRIDE);
+	  }
+	mat->setTransparency(osg::Material::FRONT_AND_BACK, alpha);
+	if (alpha == 0)
+	  ss->setRenderingHint(osg::StateSet::DEFAULT_BIN);
+	else
+	  ss->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+      }
+  }
+ 
+  void LeafNodeMesh::setTexture(const std::string& image_path)
+  {
+    osg::ref_ptr<osg::Texture2D> texture = new osg::Texture2D;
+    texture->setDataVariance(osg::Object::DYNAMIC); 
+    osg::ref_ptr<osg::Image> image = osgDB::readImageFile(image_path);
+    if (!image)
+    {
+      std::cout << " couldn't find texture, quiting." << std::endl;
+      return;
+    } 
+    texture->setImage(image);
+    mesh_geometry_ptr_->getStateSet()->setTextureAttributeAndModes(0,texture,osg::StateAttribute::ON);
+  }
+
+  osg::ref_ptr<osg::Node> LeafNodeMesh::getOsgNode() const
+  {
+    return geode_ptr_;
+  }
+
+  void LeafNodeMesh::setVertexArray(osg::Vec3ArrayRefPtr arrayOfVertices)
+  {
+    mesh_geometry_ptr_->setVertexArray(arrayOfVertices);
+  }
+
+  void LeafNodeMesh::addPrimitiveSet(osg::DrawElementsUInt * aPrimitiveSet)
+  {
+    mesh_geometry_ptr_->addPrimitiveSet(aPrimitiveSet);
+  }
+
+  void LeafNodeMesh::setColorArray(osg::Vec4ArrayRefPtr aSetOfColors)
+  {
+    mesh_geometry_ptr_->setColorArray(aSetOfColors);
+  }
+  
+  void LeafNodeMesh::setColorBinding(osg::Geometry::AttributeBinding aColorBinding)
+  {
+    mesh_geometry_ptr_->setColorBinding(aColorBinding);
+  }
+
+  void LeafNodeMesh::setNormalArray(osg::Vec3ArrayRefPtr normals)
+  {
+    mesh_geometry_ptr_->setNormalArray(normals);
+  }
+
+  void LeafNodeMesh::setNormalBinding(osg::Geometry::AttributeBinding aNormalBinding)
+  {
+    mesh_geometry_ptr_->setNormalBinding(aNormalBinding);
+  }
+
+  LeafNodeMesh::~LeafNodeMesh()
+  {
+    /* Proper deletion of all tree scene */
+    this->asQueue()->removeChild(geode_ptr_);
+    mesh_geometry_ptr_ = NULL;
+        
+    weak_ptr_.reset();
+  }
+    
+  /* End of declaration of public function members */
+    
+} /* namespace graphics */


### PR DESCRIPTION
Tested over a port of OpenHRP. 
The meshes are loaded using a classical OpenHRP ModelLoader, and provided to gepetto-viewer through a CORBA interface. 