### PR TITLE
disable small feature culling

### DIFF
--- a/src/window-manager.cpp
+++ b/src/window-manager.cpp
@@ -276,7 +276,10 @@ namespace graphics {
       GLenum buffer = traits_ptr->doubleBuffer ? GL_BACK : GL_FRONT;
       main_camera_->setDrawBuffer(buffer);
       main_camera_->setReadBuffer(buffer);
-
+      /* Disable small features culling */
+      osg::CullStack::CullingMode cullingMode = main_camera_->getCullingMode();
+      cullingMode &= ~(osg::CullStack::SMALL_FEATURE_CULLING);
+      main_camera_->setCullingMode( cullingMode );
       /* add scene to the viewer */
       viewer_ptr_->setSceneData ( scene_ptr_->asGroup() );
       


### PR DESCRIPTION
With the standard option, if a small object is too far from the camera it is not displayed. When we display discretized path as a sequence of lines, this can lead to the disappearance of some part of the path. 